### PR TITLE
Allow conversion from VersionSet to VersionReq

### DIFF
--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -159,6 +159,14 @@ impl VersionReq {
     }
 }
 
+impl<I: IntoIterator<Item=VersionSet>> From<I> for VersionReq {
+    fn from(i: I) -> Self {
+        VersionReq {
+            sets: i.into_iter().collect(),
+        }
+    }
+}
+
 impl VersionSet {
     /// `any()` is a factory method which creates a `VersionSet` with no constraints. In other
     /// words, any version will match against it.


### PR DESCRIPTION
It was previously possible to create a `VersionReq` from `VersionReq::any()`, which seems to have changed recently. This provides a way to produce `VersionReq` without needing to go through the `parse()` function.

Should there also be an explicit method on `VersionReq` for the single `VersionSet` case? `vec![VersionSet::any()].into()` is a bit verbose / unclear. Also a helper `VersionReq::any()` may still be useful?