### PR TITLE
Simplify some parsers

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,16 +24,17 @@ pub fn try_parse(i: &[u8]) -> Result<super::Version, String> {
 
 /// parse a u64
 fn number(i: &[u8]) -> IResult<&[u8], u64> {
+    use std::str::from_utf8;
     map_res!(i,
-             nom::digit,
-             |d| str::FromStr::from_str(str::from_utf8(d).unwrap()))
+             map_res!(nom::digit, from_utf8),
+             |d| str::FromStr::from_str(d))
 }
 
 /// Parse an alphanumeric or a dot ("[0-9A-Za-z.]" in regex)
 fn ascii_or_hyphen(chr: u8) -> bool {
     // dot
     chr == 46 ||
-    // dot
+    // hyphen
     chr == 45 ||
     // 0-9
     (chr >= 48 && chr <= 57) ||
@@ -76,11 +77,7 @@ named!(dot_number<&[u8], u64>, preceded!(char!('.'), number));
 named!(pre<&[u8], Option<Vec<Identifier> > >,   opt!(complete!(preceded!(tag!("-"), identifiers))));
 named!(build<&[u8], Option<Vec<Identifier> > >, opt!(complete!(preceded!(tag!("+"), identifiers))));
 
-named!(extras<&[u8], (Option<Vec<Identifier>>, Option<Vec<Identifier>>) >, chain!(
-        pre: pre ~
-        build: build,
-        || { (pre, build) }
-));
+named!(extras<&[u8], (Option<Vec<Identifier>>, Option<Vec<Identifier>>) >, pair!(pre, build));
 
 /// parse a version
 ///


### PR DESCRIPTION
A bit of nitpicking here, but it removes an `unwrap()` :)

I could simplify the `identifiers` function as well, but I run into some type inference issues right now.