### PR TITLE
Export SemVerError in the public interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ extern crate nom;
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 
-pub use version::{Version, Identifier};
+pub use version::{Version, Identifier, SemVerError};
 pub use version::Identifier::{Numeric, AlphaNumeric};
 pub use version_req::{VersionReq, ReqParseError};
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -65,6 +65,7 @@ pub struct Version {
 /// Currently, just a generic error. Will make this nicer later.
 #[derive(Clone,PartialEq,Debug,PartialOrd)]
 pub enum SemVerError {
+    /// An error ocurred while parsing.
     ParseError(String),
 }
 


### PR DESCRIPTION
This appears to have been missed in 5b7a7f8.