### PR TITLE
Parse deprecated versions.

### DIFF
--- a/tests/deprecation.rs
+++ b/tests/deprecation.rs
@@ -1,0 +1,22 @@
+extern crate semver;
+
+#[test]
+fn test_regressions() {
+    use semver::VersionReq;
+    use semver::ReqParseError;
+
+    let versions = vec![
+        (".*", VersionReq::any()),
+        ("0.1.0.", VersionReq::parse("0.1.0").unwrap()),
+        ("0.3.1.3", VersionReq::parse("0.3.13").unwrap()),
+        ("0.2*", VersionReq::parse("0.2.*").unwrap()),
+        ("*.0", VersionReq::any()),
+    ];
+
+    for (version, requirement) in versions.into_iter() {
+        let parsed = VersionReq::parse(version);
+        let error = parsed.err().unwrap();
+
+        assert_eq!(ReqParseError::DeprecatedVersionRequirement(requirement), error);
+    }
+}


### PR DESCRIPTION
Due to issues like https://github.com/rust-lang/cargo/issues/3124, we've
found that the old parser was lenient in ways that the new parser isn't.
We've analyzed all the crates on crates.io, and found the patterns that
weren't working.

This commit adds support back for those versions, but marks them as
deprecated. Each of them had a different way in which they were
incorrect, but resolved to some kind of correct constraint. So the
deprecation strategy is this:

1. If a version fails to parse, check if it matches the deprecated
pattern.
2. If it does, convert it to the real pattern.
3. Return an error that it's deprecated, and the error will contain the
fixed-up version constraint.