### PR TITLE
README.md: Update version in Cargo.toml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ packages you need installed.
 To use `semver`, add this to your `[dependencies]` section:
 
 ```toml
-semver = "0.2.0"
+semver = "0.5.0"
 ```
 
 And this to your crate root:


### PR DESCRIPTION
I'm not sure if the older version in the README.md was deliberate or not. :-)

(I'm using `semver` in Faraday's soon-to-be-announced [cage](https://github.com/faradayio/cage) tool, to [make sure that cage projects are compatible](https://github.com/faradayio/cage/commit/c970a0091adbdca64562d19fceebf81787218ee2#diff-bd5f449c6715bc3eda4d168fdaebf52eR11) with the installed version of cage. Very nicely designed!)