### PR TITLE
Bugfix for rust-lang/cargo#3202

### DIFF
--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -432,7 +432,10 @@ impl Predicate {
             Wildcard(Patch) => {
                 match self.minor {
                     Some(minor) => self.major == ver.major && minor == ver.minor,
-                    None => false,  // unreachable
+                    None => {
+                        // minor and patch version astericks mean match on major
+                        self.major == ver.major
+                    }
                 }
             }
             _ => false,  // unreachable
@@ -810,11 +813,12 @@ mod test {
     #[test]
     fn test_cargo3202() {
         let v = "0.*.*".parse::<VersionReq>().unwrap();
-
         assert_eq!("0.*.*", format!("{}", v.predicates[0]));
 
         let v = "0.0.*".parse::<VersionReq>().unwrap();
-
         assert_eq!("0.0.*", format!("{}", v.predicates[0]));
+
+        let r = req("0.*.*");
+        assert_match(&r, &["0.5.0"]);
     }
 }

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -463,7 +463,13 @@ impl fmt::Display for Predicate {
         match self.op {
             Wildcard(Major) => try!(write!(fmt, "*")),
             Wildcard(Minor) => try!(write!(fmt, "{}.*", self.major)),
-            Wildcard(Patch) => try!(write!(fmt, "{}.{}.*", self.major, self.minor.unwrap())),
+            Wildcard(Patch) => {
+                if let Some(minor) = self.minor {
+                    try!(write!(fmt, "{}.{}.*", self.major, minor))
+                } else {
+                    try!(write!(fmt, "{}.*.*", self.major))
+                }
+            }
             _ => {
                 try!(write!(fmt, "{}{}", self.op, self.major));
 
@@ -800,4 +806,15 @@ mod test {
     //    assert_eq!(Err(InvalidIdentifier), "1.0.0-".parse::<VersionReq>());
     //    assert_eq!(Err(MajorVersionRequired), ">=".parse::<VersionReq>());
     // }
+
+    #[test]
+    fn test_cargo3202() {
+        let v = "0.*.*".parse::<VersionReq>().unwrap();
+
+        assert_eq!("0.*.*", format!("{}", v.predicates[0]));
+
+        let v = "0.0.*".parse::<VersionReq>().unwrap();
+
+        assert_eq!("0.0.*", format!("{}", v.predicates[0]));
+    }
 }


### PR DESCRIPTION
We improperly assumed that if we had a wildcard patch version, we must
have a non-wildcard minor version. This is actually incorrect.