### PR TITLE
Added serde optional support to version numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,19 @@ Semantic version parsing and comparison.
 [dependencies]
 semver-parser = "0.7.0"
 
+# Serde (SERialization & DEserialization)
+serde = { version = "0.9.13", optional = true }
+# Allows for use of the derive macro for the [De]Serialize trait
+serde_derive = { version = "0.9.13", optional = true }
+
 [features]
 default = []
 
 # are we testing on CI?
 ci = []
+
+# do we want serde support? we need the library
+serde_support = ["serde", "serde_derive"]
 
 [dev-dependencies]
 crates-index = "0.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,13 @@
 
 extern crate semver_parser;
 
+// Serialization and deserialization support for version numbers
+#[cfg(feature = "serde_support")]
+#[macro_use]
+extern crate serde_derive;
+#[cfg(feature = "serde_support")]
+extern crate serde;
+
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -25,6 +25,7 @@ use semver_parser;
 ///
 /// See sections 9 and 10 of the spec for more about pre-release identifers and
 /// build metadata.
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Identifier {
     /// An identifier that's solely numbers.
@@ -53,6 +54,7 @@ impl fmt::Display for Identifier {
 }
 
 /// Represents a version number conforming to the semantic versioning scheme.
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 #[derive(Clone, Eq, Debug)]
 pub struct Version {
     /// The major version, to be incremented on incompatible changes.


### PR DESCRIPTION
The `serde_support` feature will now add the serde dependency, and allow for versions to be serialized and deserialized. I would have just called it `serde`, but you can't have an overlap of feature and dependency names.

This comes out of a personal problem I was having - since you can't define the implementation of an external trait on an external struct, I had to define the implementation manually, which is both long and boilerplate-y. This should keep the crate size down and allow for serialization as necessary.