### PR TITLE
Update to Serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", optional = true }
 default = []
 
 # are we testing on CI?
-ci = []
+ci = ["serde"]
 
 [dev-dependencies]
 crates-index = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,7 @@ Semantic version parsing and comparison.
 
 [dependencies]
 semver-parser = "0.7.0"
-
-# Serde (SERialization & DEserialization)
-serde = { version = "0.9.13", optional = true }
-# Allows for use of the derive macro for the [De]Serialize trait
-serde_derive = { version = "0.9.13", optional = true }
+serde = { version = "1.0", optional = true }
 
 [features]
 default = []
@@ -25,9 +21,8 @@ default = []
 # are we testing on CI?
 ci = []
 
-# do we want serde support? we need the library
-serde_support = ["serde", "serde_derive"]
-
 [dev-dependencies]
 crates-index = "0.5.0"
 tempdir = "0.3.4"
+serde_json = "1.0"
+serde_derive = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,10 +165,7 @@
 extern crate semver_parser;
 
 // Serialization and deserialization support for version numbers
-#[cfg(feature = "serde_support")]
-#[macro_use]
-extern crate serde_derive;
-#[cfg(feature = "serde_support")]
+#[cfg(feature = "serde")]
 extern crate serde;
 
 // We take the common approach of keeping our own module system private, and

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,78 @@
+#![cfg(feature = "serde")]
+
+#[macro_use]
+extern crate serde_derive;
+
+extern crate semver;
+extern crate serde_json;
+
+use semver::{Identifier, Version};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Identified {
+    name: String,
+    identifier: Identifier,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Versioned {
+    name: String,
+    vers: Version,
+}
+
+#[test]
+fn serialize_identifier() {
+    let id = Identified {
+        name: "serde".to_owned(),
+        identifier: Identifier::Numeric(100),
+    };
+    let j = serde_json::to_string(&id).unwrap();
+    assert_eq!(j, r#"{"name":"serde","identifier":100}"#);
+
+    let id = Identified {
+        name: "serde".to_owned(),
+        identifier: Identifier::AlphaNumeric("b100".to_owned()),
+    };
+    let j = serde_json::to_string(&id).unwrap();
+    assert_eq!(j, r#"{"name":"serde","identifier":"b100"}"#);
+}
+
+#[test]
+fn deserialize_identifier() {
+    let j = r#"{"name":"serde","identifier":100}"#;
+    let id = serde_json::from_str::<Identified>(j).unwrap();
+    let expected = Identified {
+        name: "serde".to_owned(),
+        identifier: Identifier::Numeric(100),
+    };
+    assert_eq!(id, expected);
+
+    let j = r#"{"name":"serde","identifier":"b100"}"#;
+    let id = serde_json::from_str::<Identified>(j).unwrap();
+    let expected = Identified {
+        name: "serde".to_owned(),
+        identifier: Identifier::AlphaNumeric("b100".to_owned()),
+    };
+    assert_eq!(id, expected);
+}
+
+#[test]
+fn serialize_version() {
+    let v = Versioned {
+        name: "serde".to_owned(),
+        vers: Version::parse("1.0.0").unwrap(),
+    };
+    let j = serde_json::to_string(&v).unwrap();
+    assert_eq!(j, r#"{"name":"serde","vers":"1.0.0"}"#);
+}
+
+#[test]
+fn deserialize_version() {
+    let j = r#"{"name":"serde","vers":"1.0.0"}"#;
+    let v = serde_json::from_str::<Versioned>(j).unwrap();
+    let expected = Versioned {
+        name: "serde".to_owned(),
+        vers: Version::parse("1.0.0").unwrap(),
+    };
+    assert_eq!(v, expected);
+}


### PR DESCRIPTION
I changed the representation so that this struct:

```rust
#[derive(Serialize, Deserialize)]
struct Package {
    name: String,
    vers: semver::Version,
}
```

is represented as:

```json
{"name":"serde","vers":"1.0.0"}
```

Fixes #102.