### PR TITLE
One more example for VersionReq::parse

### DIFF
--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -184,6 +184,7 @@ impl VersionReq {
     /// let version = VersionReq::parse("<1.2.3");
     /// let version = VersionReq::parse("~1.2.3");
     /// let version = VersionReq::parse("^1.2.3");
+    /// let version = VersionReq::parse("1.2.3"); // synonym for ^1.2.3
     /// let version = VersionReq::parse("<=1.2.3");
     /// let version = VersionReq::parse(">=1.2.3");
     /// ```


### PR DESCRIPTION
Looks like `^` is assumed by default. To learn this, I had to read [the test](https://github.com/matklad/semver/blob/a948b9cb591f83a9b85d74296c619bb91915c915/src/version_req.rs#L552), putting it in the docstring will make it more obvious.