### PR TITLE
libz blitz: add html root url attribute to crate root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "semver"
-version = "0.9.0"
+version = "0.9.0" # remember to update html_root_url
 authors = ["Steve Klabnik <steve@steveklabnik.com>", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/steveklabnik/semver"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,10 +158,8 @@
 //! ```
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://www.rust-lang.org/favicon.ico")]
-
-#![doc(html_root_url = "https://docs.rs/semver/0.9.0")]
-
+      html_favicon_url = "https://www.rust-lang.org/favicon.ico",
+      html_root_url = "https://docs.rs/semver/0.9.0")]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
@@ -174,9 +172,9 @@ extern crate serde;
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 
-pub use version::{Version, Identifier, SemVerError};
-pub use version::Identifier::{Numeric, AlphaNumeric};
-pub use version_req::{VersionReq, ReqParseError};
+pub use version::{Identifier, SemVerError, Version};
+pub use version::Identifier::{AlphaNumeric, Numeric};
+pub use version_req::{ReqParseError, VersionReq};
 
 // SemVer-compliant versions.
 mod version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,9 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico")]
+
+#![doc(html_root_url = "https://docs.rs/semver/0.9.0")]
+
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
Should resolve #134  