### PR TITLE
Update tests parsing not-quite-semver versions

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -362,25 +362,6 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        fn parse_error(e: &str) -> result::Result<Version, SemVerError> {
-            return Err(SemVerError::ParseError(e.to_string()));
-        }
-
-        assert_eq!(Version::parse(""),
-                   parse_error("Error parsing major identifier"));
-        assert_eq!(Version::parse("  "),
-                   parse_error("Error parsing major identifier"));
-        assert_eq!(Version::parse("1"),
-                   parse_error("Expected dot"));
-        assert_eq!(Version::parse("1.2"),
-                   parse_error("Expected dot"));
-        assert_eq!(Version::parse("1.2.3-"),
-                   parse_error("Error parsing prerelease"));
-        assert_eq!(Version::parse("a.b.c"),
-                   parse_error("Error parsing major identifier"));
-        assert_eq!(Version::parse("1.2.3 abc"),
-                   parse_error("Extra junk after valid version:  abc"));
-
         assert_eq!(Version::parse("1.2.3"),
                    Ok(Version {
                        major: 1,

--- a/src/version.rs
+++ b/src/version.rs
@@ -458,6 +458,28 @@ mod tests {
     }
 
     #[test]
+    fn test_leniant_parse() {
+        // Test that we can still parse not-quite-semvar versions.
+
+        assert_eq!(Version::parse("1.2"),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 0,
+                       pre: Vec::new(),
+                       build: Vec::new(),
+                   }));
+        assert_eq!(Version::parse("1"),
+                   Ok(Version {
+                       major: 1,
+                       minor: 0,
+                       patch: 0,
+                       pre: Vec::new(),
+                       build: Vec::new(),
+                   }));
+    }
+
+    #[test]
     fn test_increment_patch() {
         let mut buggy_release = Version::parse("0.1.0").unwrap();
         buggy_release.increment_patch();
@@ -727,8 +749,8 @@ mod tests {
 
         assert_eq!("".parse(), parse_error("Error parsing major identifier"));
         assert_eq!("  ".parse(), parse_error("Error parsing major identifier"));
-        assert_eq!("1".parse(), parse_error("Expected dot"));
-        assert_eq!("1.2".parse(),
+        assert_eq!("1a".parse(), parse_error("Expected dot"));
+        assert_eq!("1.2a".parse(),
                    parse_error("Expected dot"));
         assert_eq!("1.2.3-".parse(),
                    parse_error("Error parsing prerelease"));


### PR DESCRIPTION
Ref. Lenient parsing of not-quite-semver versions #142
Related to: Allow parsing not-quite-semver versions steveklabnik/semver-parser#25

Update the tests to reflect changes in steveklabnik/semver-parser#25 which allows for the parsing of not-quite-semver versions.

This PR expects the CI tests to fail until steveklabnik/semver-parser#25 has been merged in. In the mean time I have been running the tests by updating `Cargo.toml` to point to a local version of `semver-parser`.