### PR TITLE
libz blitz: add html root url attribute to crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,8 @@
 //! ```
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
-       html_favicon_url = "https://www.rust-lang.org/favicon.ico")]
+       html_favicon_url = "https://www.rust-lang.org/favicon.ico", 
+       html_root_url = "https://docs.rs/semver")]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
recommit based on discussion in #140 