### PR TITLE
Remove Major predicate in favor of empty predicates (fixes #150)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "semver"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Steve Klabnik <steve@steveklabnik.com>", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/steveklabnik/semver"
@@ -16,7 +16,7 @@ readme = "README.md"
 travis-ci = { repository = "steveklabnik/semver" }
 
 [dependencies]
-semver-parser = "0.7.0"
+semver-parser = "0.8.0"
 serde = { version = "1.0", optional = true }
 
 [features]


### PR DESCRIPTION
Building will fail until a published version of steveklabnik/semver-parser#29 is available.

Bumped version to `0.9.0` because:
 * WildcardVersion lost the `Major` variant.
 * Ordering of `VersionReq` is changed for the empty set of predicates which are now wildcards.