### PR TITLE
Make fields on `Version` private; add custom pre/build type (#136)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ extern crate serde;
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 
-pub use version::{Version, Identifier, SemVerError};
+pub use version::{Version, Identifier, SemVerError, MultiPartIdentifier};
 pub use version::Identifier::{Numeric, AlphaNumeric};
 pub use version_req::{VersionReq, ReqParseError};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ extern crate serde;
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 
-pub use version::{Version, Identifier, SemVerError, MultiPartIdentifier};
+pub use version::{Version, Identifier, SemVerError, MetaIdentifier};
 pub use version::Identifier::{Numeric, AlphaNumeric};
 pub use version_req::{VersionReq, ReqParseError};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,7 @@
 //! ```{rust}
 //! use semver::Version;
 //!
-//! assert!(Version::parse("1.2.3") == Ok(Version {
-//!    major: 1,
-//!    minor: 2,
-//!    patch: 3,
-//!    pre: vec!(),
-//!    build: vec!(),
-//! }));
+//! assert!(Version::parse("1.2.3") == Ok(Version::new(1, 2, 3)));
 //! ```
 //!
 //! If you have multiple `Version`s, you can use the usual comparison operators

--- a/src/version.rs
+++ b/src/version.rs
@@ -106,6 +106,7 @@ impl<'de> Deserialize<'de> for Identifier {
     }
 }
 
+/// Pre-release or build metadata, consisting of a collection of Identifiers
 #[derive(Clone, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
 pub struct MultiPartIdentifier(Vec<Identifier>);
 
@@ -146,18 +147,22 @@ impl Extend<Identifier> for MultiPartIdentifier {
 
 impl MultiPartIdentifier {
 
+    /// Creates an empty MultiPartIdentifier
     pub fn new() -> MultiPartIdentifier {
         MultiPartIdentifier(Vec::new())
     }
 
+    /// Returns true if collection of Identifiers is empty
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Returns the number of Identifiers in the collection
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Returns an Iterator over the collection of Identifiers
     pub fn iter<'a>(&'a self) -> Iter<'a> {
         self.into_iter()
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -106,32 +106,32 @@ impl<'de> Deserialize<'de> for Identifier {
     }
 }
 
-/// Pre-release or build metadata, consisting of a collection of Identifiers
+/// Pre-release or build metadata, consisting of a collection of `Identifiers`.
 #[derive(Clone, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
-pub struct MultiPartIdentifier(Vec<Identifier>);
+pub struct MetaIdentifier(Vec<Identifier>);
 
 type Iter<'a> = ::std::slice::Iter<'a, Identifier>;
 type IntoIter = ::std::vec::IntoIter<Identifier>;
 
-impl ::std::iter::FromIterator<Identifier> for MultiPartIdentifier {
+impl ::std::iter::FromIterator<Identifier> for MetaIdentifier {
     fn from_iter<I: IntoIterator<Item=Identifier>>(iter: I) -> Self {
         let mut inner = vec![];
         inner.extend(iter);
-        MultiPartIdentifier(inner)
+        MetaIdentifier(inner)
     }
 }
 
-impl From<Vec<Identifier>> for MultiPartIdentifier {
+impl From<Vec<Identifier>> for MetaIdentifier {
 
-    fn from(ids: Vec<Identifier>) -> MultiPartIdentifier {
-        let mut multipart = MultiPartIdentifier::new();
+    fn from(ids: Vec<Identifier>) -> MetaIdentifier {
+        let mut multipart = MetaIdentifier::new();
         multipart.extend(ids);
         multipart
     }
 
 }
 
-impl IntoIterator for MultiPartIdentifier {
+impl IntoIterator for MetaIdentifier {
     type Item = Identifier;
     type IntoIter = IntoIter;
 
@@ -140,7 +140,7 @@ impl IntoIterator for MultiPartIdentifier {
     }
 }
 
-impl<'a> IntoIterator for &'a MultiPartIdentifier {
+impl<'a> IntoIterator for &'a MetaIdentifier {
     type Item = &'a Identifier;
     type IntoIter = Iter<'a>;
 
@@ -149,17 +149,17 @@ impl<'a> IntoIterator for &'a MultiPartIdentifier {
     }
 }
 
-impl Extend<Identifier> for MultiPartIdentifier {
+impl Extend<Identifier> for MetaIdentifier {
     fn extend<T: IntoIterator<Item=Identifier>>(&mut self, iter: T) {
         self.0.extend(iter);
     }
 }
 
-impl MultiPartIdentifier {
+impl MetaIdentifier {
 
-    /// Creates an empty MultiPartIdentifier
-    pub fn new() -> MultiPartIdentifier {
-        MultiPartIdentifier(Vec::new())
+    /// Creates a new empty MetaIdentifier
+    pub fn new() -> MetaIdentifier {
+        MetaIdentifier(Vec::new())
     }
 
     /// Returns true if collection of Identifiers is empty
@@ -191,9 +191,9 @@ pub struct Version {
     /// fixes are made.
     patch: u64,
     /// The pre-release version identifier, if one exists.
-    pre: MultiPartIdentifier,
+    pre: MetaIdentifier,
     /// The build metadata, ignored when determining version precedence.
-    build: MultiPartIdentifier,
+    build: MetaIdentifier,
 }
 
 impl From<semver_parser::version::Version> for Version {
@@ -282,8 +282,8 @@ impl Version {
             major: major,
             minor: minor,
             patch: patch,
-            pre: MultiPartIdentifier::new(),
-            build: MultiPartIdentifier::new()
+            pre: MetaIdentifier::new(),
+            build: MetaIdentifier::new()
         }
     }
 
@@ -335,29 +335,39 @@ impl Version {
     }
 
     /// Gets the Pre version information
-    pub fn pre(&self) -> &MultiPartIdentifier {
+    pub fn pre(&self) -> &MetaIdentifier {
         &self.pre
     }
 
-    /// Gets the Build information
-    pub fn build(&self) -> &MultiPartIdentifier {
+    /// Sets the Pre version information
+    pub fn set_pre(&mut self, pre: MetaIdentifier) {
+        self.pre = pre;
+    }
+
+    /// Gets the Build version information
+    pub fn build(&self) -> &MetaIdentifier {
         &self.build
     }
 
+    /// Sets the Build version information
+    pub fn set_build(&mut self, build: MetaIdentifier) {
+        self.build = build;
+    }
+
     /// Split the Version into its constituent parts, borrowing the pre & build information
-    pub fn as_parts(&self) -> (u64, u64, u64, &MultiPartIdentifier, &MultiPartIdentifier) {
+    pub fn as_parts(&self) -> (u64, u64, u64, &MetaIdentifier, &MetaIdentifier) {
         (self.major, self.minor, self.patch, self.pre(), self.build())
     }
 
     /// Split the Version into its constituent parts, cloning the pre & build information
-    pub fn into_parts(&self) -> (u64, u64, u64, MultiPartIdentifier, MultiPartIdentifier) {
+    pub fn into_parts(&self) -> (u64, u64, u64, MetaIdentifier, MetaIdentifier) {
         (self.major, self.minor, self.patch, self.pre.clone(), self.build.clone())
     }
 
     /// Clears the build metadata
     fn clear_metadata(&mut self) {
-        self.build = MultiPartIdentifier::new();
-        self.pre = MultiPartIdentifier::new();
+        self.build = MetaIdentifier::new();
+        self.pre = MetaIdentifier::new();
     }
 
     /// Increments the patch number for this Version (Must be mutable)
@@ -493,7 +503,7 @@ mod tests {
     use std::result;
     use super::Version;
     use super::Identifier;
-    use super::MultiPartIdentifier;
+    use super::MetaIdentifier;
     use super::SemVerError;
 
     #[test]
@@ -522,8 +532,8 @@ mod tests {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::new(),
-                       build: MultiPartIdentifier::new(),
+                       pre: MetaIdentifier::new(),
+                       build: MetaIdentifier::new(),
                    }));
 
         assert_eq!(Version::parse("1.2.3"),
@@ -534,67 +544,67 @@ mod tests {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::new(),
-                       build: MultiPartIdentifier::new(),
+                       pre: MetaIdentifier::new(),
+                       build: MetaIdentifier::new(),
                    }));
         assert_eq!(Version::parse("1.2.3-alpha1"),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
-                       build: MultiPartIdentifier::new(),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MetaIdentifier::new(),
                    }));
         assert_eq!(Version::parse("  1.2.3-alpha1  "),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
-                       build: MultiPartIdentifier::new(),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MetaIdentifier::new(),
                    }));
         assert_eq!(Version::parse("1.2.3+build5"),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::new(),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                       pre: MetaIdentifier::new(),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
                    }));
         assert_eq!(Version::parse("  1.2.3+build5  "),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::new(),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                       pre: MetaIdentifier::new(),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
                    }));
         assert_eq!(Version::parse("1.2.3-alpha1+build5"),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
                    }));
         assert_eq!(Version::parse("  1.2.3-alpha1+build5  "),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
                    }));
         assert_eq!(Version::parse("1.2.3-1.alpha1.9+build5.7.3aedf  "),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::Numeric(1),
+                       pre: MetaIdentifier::from(vec![Identifier::Numeric(1),
                       Identifier::AlphaNumeric(String::from("alpha1")),
                       Identifier::Numeric(9),
             ]),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5")),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5")),
                         Identifier::Numeric(7),
                         Identifier::AlphaNumeric(String::from("3aedf")),
             ]),
@@ -604,10 +614,10 @@ mod tests {
                        major: 0,
                        minor: 4,
                        patch: 0,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("beta")),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("beta")),
                       Identifier::Numeric(1),
             ]),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("0851523"))],
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("0851523"))],
             )}));
 
     }
@@ -812,75 +822,75 @@ mod tests {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::new(),
-                       build: MultiPartIdentifier::new(),
+                       pre: MetaIdentifier::new(),
+                       build: MetaIdentifier::new(),
                    }));
         assert_eq!("  1.2.3  ".parse(),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::new(),
-                       build: MultiPartIdentifier::new(),
+                       pre: MetaIdentifier::new(),
+                       build: MetaIdentifier::new(),
                    }));
         assert_eq!("1.2.3-alpha1".parse(),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
-                       build: MultiPartIdentifier::new(),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MetaIdentifier::new(),
                    }));
         assert_eq!("  1.2.3-alpha1  ".parse(),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
-                       build: MultiPartIdentifier::new(),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MetaIdentifier::new(),
                    }));
         assert_eq!("1.2.3+build5".parse(),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::new(),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                       pre: MetaIdentifier::new(),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
                    }));
         assert_eq!("  1.2.3+build5  ".parse(),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::new(),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                       pre: MetaIdentifier::new(),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
                    }));
         assert_eq!("1.2.3-alpha1+build5".parse(),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
                    }));
         assert_eq!("  1.2.3-alpha1+build5  ".parse(),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
                    }));
         assert_eq!("1.2.3-1.alpha1.9+build5.7.3aedf  ".parse(),
                    Ok(Version {
                        major: 1,
                        minor: 2,
                        patch: 3,
-                       pre: MultiPartIdentifier::from(vec![Identifier::Numeric(1),
+                       pre: MetaIdentifier::from(vec![Identifier::Numeric(1),
                       Identifier::AlphaNumeric(String::from("alpha1")),
                       Identifier::Numeric(9),
             ]),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5")),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5")),
                         Identifier::Numeric(7),
                         Identifier::AlphaNumeric(String::from("3aedf")),
             ]),
@@ -890,10 +900,10 @@ mod tests {
                        major: 0,
                        minor: 4,
                        patch: 0,
-                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("beta")),
+                       pre: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("beta")),
                       Identifier::Numeric(1),
             ]),
-                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("0851523"))]),
+                       build: MetaIdentifier::from(vec![Identifier::AlphaNumeric(String::from("0851523"))]),
                    }));
 
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -121,6 +121,16 @@ impl ::std::iter::FromIterator<Identifier> for MultiPartIdentifier {
     }
 }
 
+impl From<Vec<Identifier>> for MultiPartIdentifier {
+
+    fn from(ids: Vec<Identifier>) -> MultiPartIdentifier {
+        let mut multipart = MultiPartIdentifier::new();
+        multipart.extend(ids);
+        multipart
+    }
+
+}
+
 impl IntoIterator for MultiPartIdentifier {
     type Item = Identifier;
     type IntoIter = IntoIter;
@@ -483,6 +493,7 @@ mod tests {
     use std::result;
     use super::Version;
     use super::Identifier;
+    use super::MultiPartIdentifier;
     use super::SemVerError;
 
     #[test]
@@ -491,143 +502,113 @@ mod tests {
             return Err(SemVerError::ParseError(e.to_string()));
         }
 
-        assert_eq!(
-            Version::parse(""),
-            parse_error("Error parsing major identifier")
-        );
-        assert_eq!(
-            Version::parse("  "),
-            parse_error("Error parsing major identifier")
-        );
-        assert_eq!(Version::parse("1"), parse_error("Expected dot"));
-        assert_eq!(Version::parse("1.2"), parse_error("Expected dot"));
-        assert_eq!(
-            Version::parse("1.2.3-"),
-            parse_error("Error parsing prerelease")
-        );
-        assert_eq!(
-            Version::parse("a.b.c"),
-            parse_error("Error parsing major identifier")
-        );
-        assert_eq!(
-            Version::parse("1.2.3 abc"),
-            parse_error("Extra junk after valid version:  abc")
-        );
+        assert_eq!(Version::parse(""),
+                   parse_error("Error parsing major identifier"));
+        assert_eq!(Version::parse("  "),
+                   parse_error("Error parsing major identifier"));
+        assert_eq!(Version::parse("1"),
+                   parse_error("Expected dot"));
+        assert_eq!(Version::parse("1.2"),
+                   parse_error("Expected dot"));
+        assert_eq!(Version::parse("1.2.3-"),
+                   parse_error("Error parsing prerelease"));
+        assert_eq!(Version::parse("a.b.c"),
+                   parse_error("Error parsing major identifier"));
+        assert_eq!(Version::parse("1.2.3 abc"),
+                   parse_error("Extra junk after valid version:  abc"));
 
-        assert_eq!(
-            Version::parse("1.2.3"),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: Vec::new(),
-                build: Vec::new(),
-            })
-        );
+        assert_eq!(Version::parse("1.2.3"),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::new(),
+                       build: MultiPartIdentifier::new(),
+                   }));
 
-        assert_eq!(Version::parse("1.2.3"), Ok(Version::new(1, 2, 3)));
+        assert_eq!(Version::parse("1.2.3"),
+                   Ok(Version::new(1,2,3)));
 
-        assert_eq!(
-            Version::parse("  1.2.3  "),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: Vec::new(),
-                build: Vec::new(),
-            })
-        );
-        assert_eq!(
-            Version::parse("1.2.3-alpha1"),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![Identifier::AlphaNumeric(String::from("alpha1"))],
-                build: Vec::new(),
-            })
-        );
-        assert_eq!(
-            Version::parse("  1.2.3-alpha1  "),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![Identifier::AlphaNumeric(String::from("alpha1"))],
-                build: Vec::new(),
-            })
-        );
-        assert_eq!(
-            Version::parse("1.2.3+build5"),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: Vec::new(),
-                build: vec![Identifier::AlphaNumeric(String::from("build5"))],
-            })
-        );
-        assert_eq!(
-            Version::parse("  1.2.3+build5  "),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: Vec::new(),
-                build: vec![Identifier::AlphaNumeric(String::from("build5"))],
-            })
-        );
-        assert_eq!(
-            Version::parse("1.2.3-alpha1+build5"),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![Identifier::AlphaNumeric(String::from("alpha1"))],
-                build: vec![Identifier::AlphaNumeric(String::from("build5"))],
-            })
-        );
-        assert_eq!(
-            Version::parse("  1.2.3-alpha1+build5  "),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![Identifier::AlphaNumeric(String::from("alpha1"))],
-                build: vec![Identifier::AlphaNumeric(String::from("build5"))],
-            })
-        );
-        assert_eq!(
-            Version::parse("1.2.3-1.alpha1.9+build5.7.3aedf  "),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![
-                    Identifier::Numeric(1),
-                    Identifier::AlphaNumeric(String::from("alpha1")),
-                    Identifier::Numeric(9),
-                ],
-                build: vec![
-                    Identifier::AlphaNumeric(String::from("build5")),
-                    Identifier::Numeric(7),
-                    Identifier::AlphaNumeric(String::from("3aedf")),
-                ],
-            })
-        );
-        assert_eq!(
-            Version::parse("0.4.0-beta.1+0851523"),
-            Ok(Version {
-                major: 0,
-                minor: 4,
-                patch: 0,
-                pre: vec![
-                    Identifier::AlphaNumeric(String::from("beta")),
-                    Identifier::Numeric(1),
-                ],
-                build: vec![Identifier::AlphaNumeric(String::from("0851523"))],
-            })
-        );
+        assert_eq!(Version::parse("  1.2.3  "),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::new(),
+                       build: MultiPartIdentifier::new(),
+                   }));
+        assert_eq!(Version::parse("1.2.3-alpha1"),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MultiPartIdentifier::new(),
+                   }));
+        assert_eq!(Version::parse("  1.2.3-alpha1  "),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MultiPartIdentifier::new(),
+                   }));
+        assert_eq!(Version::parse("1.2.3+build5"),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::new(),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                   }));
+        assert_eq!(Version::parse("  1.2.3+build5  "),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::new(),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                   }));
+        assert_eq!(Version::parse("1.2.3-alpha1+build5"),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                   }));
+        assert_eq!(Version::parse("  1.2.3-alpha1+build5  "),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                   }));
+        assert_eq!(Version::parse("1.2.3-1.alpha1.9+build5.7.3aedf  "),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::Numeric(1),
+                      Identifier::AlphaNumeric(String::from("alpha1")),
+                      Identifier::Numeric(9),
+            ]),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5")),
+                        Identifier::Numeric(7),
+                        Identifier::AlphaNumeric(String::from("3aedf")),
+            ]),
+                   }));
+        assert_eq!(Version::parse("0.4.0-beta.1+0851523"),
+                   Ok(Version {
+                       major: 0,
+                       minor: 4,
+                       patch: 0,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("beta")),
+                      Identifier::Numeric(1),
+            ]),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("0851523"))],
+            )}));
 
     }
 
@@ -826,117 +807,94 @@ mod tests {
 
     #[test]
     fn test_from_str() {
-        assert_eq!(
-            "1.2.3".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: Vec::new(),
-                build: Vec::new(),
-            })
-        );
-        assert_eq!(
-            "  1.2.3  ".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: Vec::new(),
-                build: Vec::new(),
-            })
-        );
-        assert_eq!(
-            "1.2.3-alpha1".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![Identifier::AlphaNumeric(String::from("alpha1"))],
-                build: Vec::new(),
-            })
-        );
-        assert_eq!(
-            "  1.2.3-alpha1  ".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![Identifier::AlphaNumeric(String::from("alpha1"))],
-                build: Vec::new(),
-            })
-        );
-        assert_eq!(
-            "1.2.3+build5".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: Vec::new(),
-                build: vec![Identifier::AlphaNumeric(String::from("build5"))],
-            })
-        );
-        assert_eq!(
-            "  1.2.3+build5  ".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: Vec::new(),
-                build: vec![Identifier::AlphaNumeric(String::from("build5"))],
-            })
-        );
-        assert_eq!(
-            "1.2.3-alpha1+build5".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![Identifier::AlphaNumeric(String::from("alpha1"))],
-                build: vec![Identifier::AlphaNumeric(String::from("build5"))],
-            })
-        );
-        assert_eq!(
-            "  1.2.3-alpha1+build5  ".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![Identifier::AlphaNumeric(String::from("alpha1"))],
-                build: vec![Identifier::AlphaNumeric(String::from("build5"))],
-            })
-        );
-        assert_eq!(
-            "1.2.3-1.alpha1.9+build5.7.3aedf  ".parse(),
-            Ok(Version {
-                major: 1,
-                minor: 2,
-                patch: 3,
-                pre: vec![
-                    Identifier::Numeric(1),
-                    Identifier::AlphaNumeric(String::from("alpha1")),
-                    Identifier::Numeric(9),
-                ],
-                build: vec![
-                    Identifier::AlphaNumeric(String::from("build5")),
-                    Identifier::Numeric(7),
-                    Identifier::AlphaNumeric(String::from("3aedf")),
-                ],
-            })
-        );
-        assert_eq!(
-            "0.4.0-beta.1+0851523".parse(),
-            Ok(Version {
-                major: 0,
-                minor: 4,
-                patch: 0,
-                pre: vec![
-                    Identifier::AlphaNumeric(String::from("beta")),
-                    Identifier::Numeric(1),
-                ],
-                build: vec![Identifier::AlphaNumeric(String::from("0851523"))],
-            })
-        );
+        assert_eq!("1.2.3".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::new(),
+                       build: MultiPartIdentifier::new(),
+                   }));
+        assert_eq!("  1.2.3  ".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::new(),
+                       build: MultiPartIdentifier::new(),
+                   }));
+        assert_eq!("1.2.3-alpha1".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MultiPartIdentifier::new(),
+                   }));
+        assert_eq!("  1.2.3-alpha1  ".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MultiPartIdentifier::new(),
+                   }));
+        assert_eq!("1.2.3+build5".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::new(),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                   }));
+        assert_eq!("  1.2.3+build5  ".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::new(),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                   }));
+        assert_eq!("1.2.3-alpha1+build5".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                   }));
+        assert_eq!("  1.2.3-alpha1+build5  ".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("alpha1"))]),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5"))]),
+                   }));
+        assert_eq!("1.2.3-1.alpha1.9+build5.7.3aedf  ".parse(),
+                   Ok(Version {
+                       major: 1,
+                       minor: 2,
+                       patch: 3,
+                       pre: MultiPartIdentifier::from(vec![Identifier::Numeric(1),
+                      Identifier::AlphaNumeric(String::from("alpha1")),
+                      Identifier::Numeric(9),
+            ]),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("build5")),
+                        Identifier::Numeric(7),
+                        Identifier::AlphaNumeric(String::from("3aedf")),
+            ]),
+                   }));
+        assert_eq!("0.4.0-beta.1+0851523".parse(),
+                   Ok(Version {
+                       major: 0,
+                       minor: 4,
+                       patch: 0,
+                       pre: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("beta")),
+                      Identifier::Numeric(1),
+            ]),
+                       build: MultiPartIdentifier::from(vec![Identifier::AlphaNumeric(String::from("0851523"))]),
+                   }));
 
     }
 

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use std::str;
 
 use Version;
-use version::MultiPartIdentifier;
+use version::MetaIdentifier;
 use semver_parser;
 
 #[cfg(feature = "serde")]
@@ -125,7 +125,7 @@ struct Predicate {
     major: u64,
     minor: Option<u64>,
     patch: Option<u64>,
-    pre: MultiPartIdentifier,
+    pre: MetaIdentifier,
 }
 
 impl From<semver_parser::range::Predicate> for Predicate {

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -275,7 +275,7 @@ impl VersionReq {
     /// use semver::VersionReq;
     /// use semver::Version;
     ///
-    /// let version = Version { major: 1, minor: 1, patch: 1, pre: vec![], build: vec![] };
+    /// let version = Version::new(1, 1, 1);
     /// let exact = VersionReq::exact(&version);
     /// ```
     pub fn exact(version: &Version) -> VersionReq {
@@ -290,7 +290,7 @@ impl VersionReq {
     /// use semver::VersionReq;
     /// use semver::Version;
     ///
-    /// let version = Version { major: 1, minor: 1, patch: 1, pre: vec![], build: vec![] };
+    /// let version = Version::new(1, 1, 1);
     /// let exact = VersionReq::exact(&version);
     ///
     /// assert!(exact.matches(&version));


### PR DESCRIPTION
This is a first draft of fixing #136. It sets all the fields of Version to private and adds a new `MetaIdentifier` type, which wraps the previous `Vec<Identifier>` for build/pre fields. There are some extra methods added to `Version` to coincide with making all fields private (`into_parts`, `as_parts`, `set_pre`, `set_build`).

This is a pretty hefty change to the API, happy to discuss any of these changes.