### PR TITLE
Fix #124: ^0.11.0-rc.2 should not match 0.11.0

### DIFF
--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -468,7 +468,7 @@ impl Predicate {
     }
 
     fn pre_is_compatible(&self, ver: &Version) -> bool {
-        ver.pre.is_empty() || ver.pre >= self.pre
+        ver.pre >= self.pre
     }
 
     // see https://www.npmjs.org/doc/misc/semver.html for behavior
@@ -585,13 +585,13 @@ mod test {
 
     fn assert_match(req: &VersionReq, vers: &[&str]) {
         for ver in vers.iter() {
-            assert!(req.matches(&version(*ver)), "did not match {}", ver);
+            assert!(req.matches(&version(*ver)), "{} did not match {}", req, ver);
         }
     }
 
     fn assert_not_match(req: &VersionReq, vers: &[&str]) {
         for ver in vers.iter() {
-            assert!(!req.matches(&version(*ver)), "matched {}", ver);
+            assert!(!req.matches(&version(*ver)), "{} matched {}", req, ver);
         }
     }
 
@@ -747,8 +747,8 @@ mod test {
         assert_not_match(&r, &["1.2.1", "1.9.0", "1.0.9", "2.0.1", "0.1.3"]);
 
         let r = req("~1.2.3-beta.2");
-        assert_match(&r, &["1.2.3", "1.2.4", "1.2.3-beta.2", "1.2.3-beta.4"]);
-        assert_not_match(&r, &["1.3.3", "1.1.4", "1.2.3-beta.1", "1.2.4-beta.2"]);
+        assert_match(&r, &["1.2.4", "1.2.3-beta.2", "1.2.3-beta.4"]);
+        assert_not_match(&r, &["1.2.3", "1.3.3", "1.1.4", "1.2.3-beta.1", "1.2.4-beta.2"]);
     }
 
     #[test]
@@ -779,13 +779,13 @@ mod test {
                 "0.5.1-alpha3",
                 "0.5.1-alpha4",
                 "0.5.1-beta",
-                "0.5.1",
                 "0.5.5",
             ],
         );
         assert_not_match(
             &r,
             &[
+                "0.5.1",
                 "0.5.1-alpha1",
                 "0.5.2-alpha3",
                 "0.5.5-pre",
@@ -809,11 +809,12 @@ mod test {
         let r = req("^1.4.2-beta.5");
         assert_match(
             &r,
-            &["1.4.2", "1.4.3", "1.4.2-beta.5", "1.4.2-beta.6", "1.4.2-c"],
+            &["1.4.3", "1.4.2-beta.5", "1.4.2-beta.6", "1.4.2-c"],
         );
         assert_not_match(
             &r,
             &[
+                "1.4.2",
                 "0.9.9",
                 "2.0.0",
                 "1.4.2-alpha",
@@ -821,6 +822,10 @@ mod test {
                 "1.4.3-beta.5",
             ],
         );
+        
+        let r = req("0.11.0-rc.2");
+        assert_match(&r, &["0.11.0-rc.2", "0.11.0-rc.3", "0.11.0-rd", "0.11.1"]);
+        assert_not_match(&r, &["0.11.0", "0.11.0-rc.1", "0.11.0-ra", "0.12.0"]);
     }
 
     #[test]


### PR DESCRIPTION
This broke a few tests, but my reading of the rules is that these did not match spec:
https://docs.npmjs.com/misc/semver#tilde-ranges-123-12-1

On the other hand whether *we want* to make this change I don't know:

*   The current rules effectively mean `0.11.0-rc.2 < 0.11.0` — that test itself won't pass but the compatibility (`^`) rule allows people to treat it almost like it is (note though that `^0.11.0` will never match `0.11.0-rc.2` due to restriction on prerelease tags)
*   It may be valid to consider effectively `x.y.z-A < x.y.z` for all x/y/z/A (see [my other comment](https://github.com/steveklabnik/semver/issues/128#issuecomment-350714157))