### PR TITLE
Add Diesel support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ travis-ci = { repository = "steveklabnik/semver" }
 [dependencies]
 semver-parser = "0.7.0"
 serde = { version = "1.0", optional = true }
+diesel = { version = "1.0.0", optional = true }
 
 [features]
 default = []

--- a/src/diesel_impls.rs
+++ b/src/diesel_impls.rs
@@ -1,0 +1,44 @@
+use diesel::backend::Backend;
+use diesel::types::{FromSql, ToSql, IsNull, ToSqlOutput, Text};
+use std::io::Write;
+use std::error::Error;
+
+use {Version, VersionReq};
+
+impl<DB> FromSql<Text, DB> for Version
+where
+    DB: Backend,
+    *const str: FromSql<Text, DB>,
+{
+    fn from_sql(input: Option<&DB::RawValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        let str_ptr = <*const str as FromSql<Text, DB>>::from_sql(input)?;
+        let s = unsafe { &*str_ptr };
+        s.parse().map_err(Into::into)
+    }
+}
+
+impl<DB: Backend> ToSql<Text, DB> for Version {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error + Send + Sync>> {
+        write!(out, "{}", self)?;
+        Ok(IsNull::No)
+    }
+}
+
+impl<DB> FromSql<Text, DB> for VersionReq
+where
+    DB: Backend,
+    *const str: FromSql<Text, DB>,
+{
+    fn from_sql(input: Option<&DB::RawValue>) -> Result<Self, Box<Error + Send + Sync>> {
+        let str_ptr = <*const str as FromSql<Text, DB>>::from_sql(input)?;
+        let s = unsafe { &*str_ptr };
+        s.parse().map_err(Into::into)
+    }
+}
+
+impl<DB: Backend> ToSql<Text, DB> for VersionReq {
+    fn to_sql<W: Write>(&self, out: &mut ToSqlOutput<W, DB>) -> Result<IsNull, Box<Error + Send + Sync>> {
+        write!(out, "{}", self)?;
+        Ok(IsNull::No)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,11 @@ extern crate semver_parser;
 #[cfg(feature = "serde")]
 extern crate serde;
 
+// Database support for version numbers
+#[cfg(feature = "diesel")]
+#[macro_use]
+extern crate diesel;
+
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 
@@ -181,3 +186,7 @@ mod version;
 
 // advanced version comparisons
 mod version_req;
+
+#[cfg(feature = "diesel")]
+// Diesel support
+mod diesel_impls;

--- a/src/version.rs
+++ b/src/version.rs
@@ -108,6 +108,8 @@ impl<'de> Deserialize<'de> for Identifier {
 
 /// Represents a version number conforming to the semantic versioning scheme.
 #[derive(Clone, Eq, Debug)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", sql_type = "diesel::types::Text")]
 pub struct Version {
     /// The major version, to be incremented on incompatible changes.
     pub major: u64,

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -29,6 +29,8 @@ use self::ReqParseError::*;
 /// numbers. Matching operations can then be done with the `VersionReq` against a particular
 /// version to see if it satisfies some or all of the constraints.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "diesel", derive(AsExpression))]
+#[cfg_attr(feature = "diesel", sql_type = "diesel::types::Text")]
 pub struct VersionReq {
     predicates: Vec<Predicate>,
 }


### PR DESCRIPTION
Note: This code targets Diesel 1.1, and needs tests. It is not yet ready
to merge. I wanted to get an idea of whether this would even be
considered before I add tests. I can support Diesel 1.0 if it's
required, but it will require a lot more code. Impls like this are the
main focus of 1.1. If you'd like to verify that this compiles,
this is based off of a branch of Diesel master with PRs
https://github.com/diesel-rs/diesel/pull/1458,
https://github.com/diesel-rs/diesel/pull/1455,
and https://github.com/diesel-rs/diesel/pull/1463 merged.
This should be fully representative of what the code will look like
when Diesel 1.1 is actually released (though I will probably add
a type alias for the return types of `ToSql` and `FromSql` in addition
to this).

While it'd be great if we could just have a diesel-semver crate, Rust
today requires that this be either in Diesel or Semver.

This makes the same assumptions as the serde implementations. We assume
that the values are being stored as a string, and getting them in/out is
just `FromStr` and `Display`.

I've opted to only support `Version` and `VersionReq` in this case.
Though the serde implementation supports `Identifier`, there's not an
obvious database agnostic way to store that type, and I don't think it's
nearly as commonly used as the other two.

I've written this implementation to be zero-cost in both directions.
Unfortunately this requires unsafe code (we can't provide a `FromSql`
impl for `&'a str` without adding a lifetime to `FromSql`. The best we
can do is `*const str` until Diesel 2.0). If the use of unsafe code is problematic,
I can change this to be based on `String` instead (which will actually be slightly
less code). The cost there will be the additional heap allocation. The code is "unsafe",
but the implementation of `FromSql` for `*const str` is pretty clear on the invariant:
It's safe to use from another `FromSql` implementation. It lives as long as the argument
to `from_sql`.

Given that this crate supports Serde, I think it makes just as much
sense to add minimal Diesel support with the same assumptions.
Especially given that it's only ~40 lines of code. This change will
enable the removal of around a hundred lines from crates.io, and enable
a bunch of refactorings that I've been wanting to do there.
  