### PR TITLE
Add Diesel support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,8 @@ addons:
 notifications:
   email:
     on_success: never
+# https://github.com/rust-lang/rust/issues/47139
+matrix:
+  allow_failures:
+    - rust: beta
+    - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,3 @@ addons:
 notifications:
   email:
     on_success: never
-# https://github.com/rust-lang/rust/issues/47139
-matrix:
-  allow_failures:
-    - rust: beta
-    - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,13 @@ travis-ci = { repository = "steveklabnik/semver" }
 [dependencies]
 semver-parser = "0.7.0"
 serde = { version = "1.0", optional = true }
+diesel = { version = "1.1", optional = true }
 
 [features]
 default = []
 
 # are we testing on CI?
-ci = ["serde"]
+ci = ["serde", "diesel/sqlite"]
 
 [dev-dependencies]
 crates-index = "0.5.0"

--- a/src/diesel_impls.rs
+++ b/src/diesel_impls.rs
@@ -1,0 +1,45 @@
+use diesel::backend::Backend;
+use diesel::deserialize::{self, FromSql};
+use diesel::serialize::{self, ToSql, Output, IsNull};
+use diesel::sql_types::Text;
+use std::io::Write;
+
+use {Version, VersionReq};
+
+impl<DB> FromSql<Text, DB> for Version
+where
+    DB: Backend,
+    *const str: FromSql<Text, DB>,
+{
+    fn from_sql(input: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+        let str_ptr = <*const str as FromSql<Text, DB>>::from_sql(input)?;
+        let s = unsafe { &*str_ptr };
+        s.parse().map_err(Into::into)
+    }
+}
+
+impl<DB: Backend> ToSql<Text, DB> for Version {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
+        write!(out, "{}", self)?;
+        Ok(IsNull::No)
+    }
+}
+
+impl<DB> FromSql<Text, DB> for VersionReq
+where
+    DB: Backend,
+    *const str: FromSql<Text, DB>,
+{
+    fn from_sql(input: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+        let str_ptr = <*const str as FromSql<Text, DB>>::from_sql(input)?;
+        let s = unsafe { &*str_ptr };
+        s.parse().map_err(Into::into)
+    }
+}
+
+impl<DB: Backend> ToSql<Text, DB> for VersionReq {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> serialize::Result {
+        write!(out, "{}", self)?;
+        Ok(IsNull::No)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,11 @@ extern crate semver_parser;
 #[cfg(feature = "serde")]
 extern crate serde;
 
+// Database support for version numbers
+#[cfg(feature = "diesel")]
+#[macro_use]
+extern crate diesel;
+
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 
@@ -181,3 +186,7 @@ mod version;
 
 // advanced version comparisons
 mod version_req;
+
+#[cfg(feature = "diesel")]
+// Diesel support
+mod diesel_impls;

--- a/src/version.rs
+++ b/src/version.rs
@@ -108,6 +108,8 @@ impl<'de> Deserialize<'de> for Identifier {
 
 /// Represents a version number conforming to the semantic versioning scheme.
 #[derive(Clone, Eq, Debug)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", sql_type = "diesel::sql_types::Text")]
 pub struct Version {
     /// The major version, to be incremented on incompatible changes.
     pub major: u64,

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -29,6 +29,8 @@ use self::ReqParseError::*;
 /// numbers. Matching operations can then be done with the `VersionReq` against a particular
 /// version to see if it satisfies some or all of the constraints.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
+#[cfg_attr(feature = "diesel", sql_type = "diesel::sql_types::Text")]
 pub struct VersionReq {
     predicates: Vec<Predicate>,
 }

--- a/tests/diesel.rs
+++ b/tests/diesel.rs
@@ -1,0 +1,214 @@
+#![cfg(feature = "diesel")]
+
+#[macro_use]
+extern crate diesel;
+extern crate semver;
+
+use diesel::*;
+use diesel::connection::SimpleConnection;
+use diesel::sql_types::Text;
+use semver::{Version, VersionReq};
+
+table! {
+    versions (name) {
+        name -> Text,
+        vers -> Text,
+    }
+}
+
+table! {
+    version_reqs (name) {
+        name -> Text,
+        req -> Text,
+    }
+}
+
+fn connection() -> SqliteConnection {
+    let conn = SqliteConnection::establish(":memory:").unwrap();
+    conn.batch_execute(
+        "
+        CREATE TABLE versions (name TEXT PRIMARY KEY NOT NULL, vers TEXT NOT NULL);
+        CREATE TABLE version_reqs (name TEXT PRIMARY KEY NOT NULL, req TEXT NOT NULL);
+    ",
+    ).unwrap();
+    conn
+}
+
+const VERSIONS_TO_TEST: &[&str] = &[
+    "0.0.1",
+    "0.1.0",
+    "1.0.0",
+    "1.0.0-beta1",
+    "1.0.0-beta.1",
+    "1.0.0+129384712983",
+    "1.0.0-beta.1+1234.5678",
+];
+
+#[test]
+fn version_round_trips() {
+    let conn = connection();
+    for version in VERSIONS_TO_TEST {
+        let version = version.parse::<Version>().unwrap();
+        let result = select(version.as_sql::<Text>()).get_result(&conn);
+        assert_eq!(Ok(version), result);
+    }
+}
+
+#[test]
+fn version_inserts_and_loads() {
+    use self::versions::dsl::*;
+
+    let conn = connection();
+    let semver_versions = VERSIONS_TO_TEST
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            (format!("Version {}", i), v.parse::<Version>().unwrap())
+        })
+        .collect::<Vec<_>>();
+
+    let new_versions = semver_versions
+        .iter()
+        .map(|&(ref n, ref v)| (name.eq(n), vers.eq(v)))
+        .collect::<Vec<_>>();
+    let inserted_rows = insert_into(versions).values(&new_versions).execute(&conn);
+    assert_eq!(Ok(VERSIONS_TO_TEST.len()), inserted_rows);
+
+    let actual_data = versions.load(&conn);
+    assert_eq!(Ok(semver_versions.clone()), actual_data);
+}
+
+#[test]
+fn version_inserts_and_loads_on_struct() {
+    #[derive(Debug, PartialEq, Queryable, Insertable)]
+    #[table_name = "versions"]
+    struct Versioned {
+        name: String,
+        vers: Version,
+    }
+
+    let conn = connection();
+    let semver_versions = VERSIONS_TO_TEST
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            Versioned {
+                name: format!("Version {}", i),
+                vers: v.parse::<Version>().unwrap(),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let inserted_rows = insert_into(versions::table)
+        .values(&semver_versions)
+        .execute(&conn);
+    assert_eq!(Ok(VERSIONS_TO_TEST.len()), inserted_rows);
+
+    let actual_data = versions::table.load(&conn);
+    assert_eq!(Ok(semver_versions), actual_data);
+}
+
+const VERSION_REQS_TO_TEST: &[&str] = &[
+    "^1.0.0",
+    "= 1.0.0",
+    "= 0.9.0",
+    "= 0.1.0-beta2.a",
+    ">= 1.0.0",
+    ">= 2.1.0-alpha2",
+    "< 1.0.0",
+    "<= 2.1.0-alpha2",
+    "^ 1.2.3+meta",
+    "= 1.2.3+meta",
+    "> 1.2.3+meta",
+    ">= 1.2.3+meta",
+    "< 1.2.3+meta",
+    "<= 1.2.3+meta",
+    "~ 1.2.3+meta",
+    "> 0.0.9, <= 2.5.3",
+    "0.3.0, 0.4.0",
+    "<= 0.2.0, >= 0.5.0",
+    "0.1.0, 0.1.4, 0.1.6",
+    ">=0.5.1-alpha3, <0.6",
+    "~1",
+    "~1.2",
+    "~1.2.2",
+    "~1.2.3-beta.2",
+    "^1",
+    "^1.1",
+    "^1.1.2",
+    "^0.1.2",
+    "^0.5.1-alpha3",
+    "",
+    "*",
+    "x",
+    "1.*",
+];
+
+#[test]
+fn version_req_round_trips() {
+    let conn = connection();
+    for version_req in VERSION_REQS_TO_TEST {
+        let version_req = version_req.parse::<VersionReq>().unwrap();
+        let result = select(version_req.as_sql::<Text>()).get_result(&conn);
+        assert_eq!(Ok(version_req), result);
+    }
+}
+
+#[test]
+fn version_req_inserts_and_loads() {
+    use self::version_reqs::dsl::*;
+
+    let conn = connection();
+    let semver_version_reqs = VERSION_REQS_TO_TEST
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            (
+                format!("VersionReq {}", i),
+                v.parse::<VersionReq>().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let new_version_reqs = semver_version_reqs
+        .iter()
+        .map(|&(ref n, ref v)| (name.eq(n), req.eq(v)))
+        .collect::<Vec<_>>();
+    let inserted_rows = insert_into(version_reqs)
+        .values(&new_version_reqs)
+        .execute(&conn);
+    assert_eq!(Ok(VERSION_REQS_TO_TEST.len()), inserted_rows);
+
+    let actual_data = version_reqs.load(&conn);
+    assert_eq!(Ok(semver_version_reqs.clone()), actual_data);
+}
+
+#[test]
+fn version_req_inserts_and_loads_on_struct() {
+    #[derive(Debug, PartialEq, Queryable, Insertable)]
+    #[table_name = "version_reqs"]
+    struct VersionReqed {
+        name: String,
+        req: VersionReq,
+    }
+
+    let conn = connection();
+    let semver_version_reqs = VERSION_REQS_TO_TEST
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            VersionReqed {
+                name: format!("VersionReq {}", i),
+                req: v.parse::<VersionReq>().unwrap(),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let inserted_rows = insert_into(version_reqs::table)
+        .values(&semver_version_reqs)
+        .execute(&conn);
+    assert_eq!(Ok(VERSION_REQS_TO_TEST.len()), inserted_rows);
+
+    let actual_data = version_reqs::table.load(&conn);
+    assert_eq!(Ok(semver_version_reqs), actual_data);
+}


### PR DESCRIPTION
This code targets Diesel 1.1. I can support Diesel 1.0 if it's required,
but it will require a lot more code. Impls like this are the main focus
of 1.1.

While it'd be great if we could just have a diesel-semver crate, Rust
today requires that this be either in Diesel or Semver.

This makes the same assumptions as the serde implementations. We assume
that the values are being stored as a string, and getting them in/out is
just `FromStr` and `Display`.

I've opted to only support `Version` and `VersionReq` in this case.
Though the serde implementation supports `Identifier`, there's not an
obvious database agnostic way to store that type, and I don't think it's
nearly as commonly used as the other two.

Given that this crate supports Serde, I think it makes just as much
sense to add minimal Diesel support with the same assumptions.
Especially given that it's only ~40 lines of code. This change will
enable the removal of around a hundred lines from crates.io, and enable
a bunch of refactorings that I've been wanting to do there.