### PR TITLE
Upgrade to new semver-parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["development-tools", "parsing"]
 travis-ci = { repository = "steveklabnik/semver" }
 
 [dependencies]
-semver-parser = "0.7.0"
+semver-parser = "0.9.0"
 serde = { version = "1.0", optional = true }
 diesel = { version = "1.1", optional = true }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -243,7 +243,7 @@ impl Version {
 
         match res {
             // Convert plain String error into proper ParseError
-            Err(e) => Err(SemVerError::ParseError(e)),
+            Err(e) => Err(SemVerError::ParseError(e.to_string())),
             Ok(v) => Ok(From::from(v)),
         }
     }
@@ -400,25 +400,25 @@ mod tests {
 
         assert_eq!(
             Version::parse(""),
-            parse_error("Error parsing major identifier")
+            parse_error("expected more input")
         );
         assert_eq!(
             Version::parse("  "),
-            parse_error("Error parsing major identifier")
+            parse_error("expected more input")
         );
-        assert_eq!(Version::parse("1"), parse_error("Expected dot"));
-        assert_eq!(Version::parse("1.2"), parse_error("Expected dot"));
+        assert_eq!(Version::parse("1"), parse_error("expected more input"));
+        assert_eq!(Version::parse("1.2"), parse_error("expected more input"));
         assert_eq!(
             Version::parse("1.2.3-"),
-            parse_error("Error parsing prerelease")
+            parse_error("expected more input")
         );
         assert_eq!(
             Version::parse("a.b.c"),
-            parse_error("Error parsing major identifier")
+            parse_error("encountered unexpected token: AlphaNumeric(\"a\")")
         );
         assert_eq!(
             Version::parse("1.2.3 abc"),
-            parse_error("Extra junk after valid version:  abc")
+            parse_error("expected end of input, but got: [AlphaNumeric(\"abc\")]")
         );
 
         assert_eq!(
@@ -861,18 +861,18 @@ mod tests {
             return Err(SemVerError::ParseError(e.to_string()));
         }
 
-        assert_eq!("".parse(), parse_error("Error parsing major identifier"));
-        assert_eq!("  ".parse(), parse_error("Error parsing major identifier"));
-        assert_eq!("1".parse(), parse_error("Expected dot"));
-        assert_eq!("1.2".parse(), parse_error("Expected dot"));
-        assert_eq!("1.2.3-".parse(), parse_error("Error parsing prerelease"));
+        assert_eq!("".parse(), parse_error("expected more input"));
+        assert_eq!("  ".parse(), parse_error("expected more input"));
+        assert_eq!("1".parse(), parse_error("expected more input"));
+        assert_eq!("1.2".parse(), parse_error("expected more input"));
+        assert_eq!("1.2.3-".parse(), parse_error("expected more input"));
         assert_eq!(
             "a.b.c".parse(),
-            parse_error("Error parsing major identifier")
+            parse_error("encountered unexpected token: AlphaNumeric(\"a\")")
         );
         assert_eq!(
             "1.2.3 abc".parse(),
-            parse_error("Extra junk after valid version:  abc")
+            parse_error("expected end of input, but got: [AlphaNumeric(\"abc\")]")
         );
     }
 }

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -22,7 +22,7 @@ use serde::ser::{Serialize, Serializer};
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 
 use self::Op::{Ex, Gt, GtEq, Lt, LtEq, Tilde, Compatible, Wildcard};
-use self::WildcardVersion::{Major, Minor, Patch};
+use self::WildcardVersion::{Minor, Patch};
 use self::ReqParseError::*;
 
 /// A `VersionReq` is a struct containing a list of predicates that can apply to ranges of version
@@ -82,7 +82,6 @@ impl<'de> Deserialize<'de> for VersionReq {
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 enum WildcardVersion {
-    Major,
     Minor,
     Patch,
 }
@@ -112,7 +111,6 @@ impl From<semver_parser::range::Op> for Op {
             range::Op::Compatible => Op::Compatible,
             range::Op::Wildcard(version) => {
                 match version {
-                    range::WildcardVersion::Major => Op::Wildcard(WildcardVersion::Major),
                     range::WildcardVersion::Minor => Op::Wildcard(WildcardVersion::Minor),
                     range::WildcardVersion::Patch => Op::Wildcard(WildcardVersion::Patch),
                 }
@@ -273,7 +271,7 @@ impl VersionReq {
 
         return match VersionReq::parse_deprecated(input) {
             Some(v) => Err(ReqParseError::DeprecatedVersionRequirement(v)),
-            None => Err(From::from(res.err().unwrap())),
+            None => Err(ReqParseError::from(res.err().unwrap().to_string())),
         };
     }
 
@@ -496,7 +494,6 @@ impl Predicate {
     // see https://www.npmjs.org/doc/misc/semver.html for behavior
     fn matches_wildcard(&self, ver: &Version) -> bool {
         match self.op {
-            Wildcard(Major) => true,
             Wildcard(Minor) => self.major == ver.major,
             Wildcard(Patch) => {
                 match self.minor {
@@ -533,7 +530,6 @@ impl fmt::Display for VersionReq {
 impl fmt::Display for Predicate {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self.op {
-            Wildcard(Major) => try!(write!(fmt, "*")),
             Wildcard(Minor) => try!(write!(fmt, "{}.*", self.major)),
             Wildcard(Patch) => {
                 if let Some(minor) = self.minor {
@@ -976,13 +972,13 @@ mod test {
 
     #[test]
     fn test_ordering() {
-        assert!(req("=1") < req("*"));
-        assert!(req(">1") < req("*"));
-        assert!(req(">=1") < req("*"));
-        assert!(req("<1") < req("*"));
-        assert!(req("<=1") < req("*"));
-        assert!(req("~1") < req("*"));
-        assert!(req("^1") < req("*"));
+        assert!(req("=1") > req("*"));
+        assert!(req(">1") > req("*"));
+        assert!(req(">=1") > req("*"));
+        assert!(req("<1") > req("*"));
+        assert!(req("<=1") > req("*"));
+        assert!(req("~1") > req("*"));
+        assert!(req("^1") > req("*"));
         assert!(req("*") == req("*"));
     }
 }


### PR DESCRIPTION
@udoprog, I've released a 0.9.0 of semver-parser with your parser in it. I was also looking at https://github.com/steveklabnik/semver/pull/151. Here's the result. I have concerns:

1. These error messages seem *way* worse
2. The regression suite now panics

Any thoughts here? I'm second-guessing the decision, to be honest.