### PR TITLE
Correct crate category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Semantic version parsing and comparison.
 """
 readme = "README.md"
 keywords = ["version", "semantic", "compare"]
-categories = ["development-tools", "parsing"]
+categories = ["development-tools", "parser-implementations"]
 
 [badges]
 travis-ci = { repository = "steveklabnik/semver" }


### PR DESCRIPTION
"parsing" category is for tools for building parsers, not parsers of particular formats.