### PR TITLE
Fix npmjs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ assert!(r.matches(&v))
 ```
 
 It also allows parsing of `~x.y.z` and `^x.y.z` requirements as defined at
-https://www.npmjs.org/doc/misc/semver.html
+https://www.npmjs.com/package/semver
 
 **Tilde requirements** specify a minimal version with some updates:
 


### PR DESCRIPTION
https://www.npmjs.com/doc/misc/semver.html is a 404. The Internet
Archive does not have it so I can only take a guess at what was hosted
at this address. Taking a guess at https://www.npmjs.com/package/semver.