### PR TITLE
Add blank line to fix doc link resolution.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 //!
 //! At its simplest, the `semver` crate allows you to construct [`Version`]
 //! objects using the [`parse`] method:
+//!
 //! [`parse`]: struct.Version.html#method.parse
 //!
 //! ```{rust}


### PR DESCRIPTION
Running `cargo doc` with a recent nightly version results in these warnings:

    warning: `[parse]` cannot be resolved, ignoring it...
      --> src/lib.rs:44:24
       |
    44 | //! objects using the [`parse`] method:
       |                        ^^^^^^^ cannot be resolved, ignoring
       |
       = note: #[warn(intra_doc_link_resolution_failure)] on by default
       = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

    warning: `[parse]` cannot be resolved, ignoring it...
      --> src/lib.rs:45:6
       |
    45 | //! [`parse`]: struct.Version.html#method.parse
       |      ^^^^^^^ cannot be resolved, ignoring
       |
       = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

The link target needs to go in a separate paragraph, so we need a blank line before it, and doing so fixes the warning for me.