### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -193,13 +193,7 @@ impl fmt::Display for SemVerError {
     }
 }
 
-impl Error for SemVerError {
-    fn description(&self) -> &str {
-        match self {
-            &SemVerError::ParseError(ref m) => m,
-        }
-    }
-}
+impl Error for SemVerError {}
 
 /// A Result type for errors
 pub type Result<T> = result::Result<T, SemVerError>;

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -167,13 +167,7 @@ pub enum ReqParseError {
 
 impl fmt::Display for ReqParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
-    }
-}
-
-impl Error for ReqParseError {
-    fn description(&self) -> &str {
-        match self {
+        let msg = match self {
             &InvalidVersionRequirement => "the given version requirement is invalid",
             &OpAlreadySet => {
                 "you have already provided an operation, such as =, ~, or ^; only use one"
@@ -186,9 +180,12 @@ impl Error for ReqParseError {
                 "the given version requirement is not implemented, yet"
             }
             &DeprecatedVersionRequirement(_) => "This requirement is deprecated",
-        }
+        };
+        msg.fmt(f)
     }
 }
+
+impl Error for ReqParseError {}
 
 impl From<String> for ReqParseError {
     fn from(other: String) -> ReqParseError {


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes the implementation of `description` 

Related PR: https://github.com/rust-lang/rust/pull/66919