### PR TITLE
added const to the constructors for Version and VersionReq

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -206,7 +206,7 @@ pub type Result<T> = result::Result<T, SemVerError>;
 
 impl Version {
     /// Contructs the simple case without pre or build.
-    pub fn new(major: u64, minor: u64, patch: u64) -> Version {
+    pub const fn new(major: u64, minor: u64, patch: u64) -> Version {
         Version {
             major: major,
             minor: minor,

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -211,8 +211,8 @@ impl VersionReq {
     ///
     /// let anything = VersionReq::any();
     /// ```
-    pub fn any() -> VersionReq {
-        VersionReq { predicates: vec![] }
+    pub const fn any() -> VersionReq {
+        VersionReq { predicates: Vec::new() }
     }
 
     /// `parse()` is the main constructor of a `VersionReq`. It takes a string like `"^1.2.3"`


### PR DESCRIPTION
No-op PR to enable users to write things like `const MINIMUM_VERSION: Version = Version::new(1,7,3);`