### PR TITLE
semver-parser 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ keywords = ["version", "semantic", "compare"]
 categories = ["development-tools", "parser-implementations"]
 
 [dependencies]
-semver-parser = "0.7.0"
+#semver-parser = "0.7.0"
+semver-parser = { git = "https://github.com/mikrostew/semver-parser", branch = "rewrite" }
+
 serde = { version = "1.0", optional = true }
 diesel = { version = "1.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,13 @@ keywords = ["version", "semantic", "compare"]
 categories = ["development-tools", "parser-implementations"]
 
 [dependencies]
-#semver-parser = "0.7.0"
-semver-parser = { git = "https://github.com/mikrostew/semver-parser", branch = "rewrite" }
+semver-parser = "0.10.0"
 
 serde = { version = "1.0", optional = true }
 diesel = { version = "1.1", optional = true }
+
+[patch.crates-io]
+semver-parser = { git = "https://github.com/steveklabnik/semver-parser" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", optional = true }
 diesel = { version = "1.1", optional = true }
 
 [patch.crates-io]
-semver-parser = { git = "https://github.com/hone/semver-parser" }
+semver-parser = { git = "https://github.com/hone/semver-parser", branch = "npm-rename" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", optional = true }
 diesel = { version = "1.1", optional = true }
 
 [patch.crates-io]
-semver-parser = { git = "https://github.com/steveklabnik/semver-parser" }
+semver-parser = { git = "https://github.com/hone/semver-parser" }
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@
 //! use semver::VersionReq;
 //!
 //! # fn try_compare() -> Result<(), Box<::std::error::Error>> {
-//! let r = VersionReq::parse(">= 1.0.0")?;
+//! let r = VersionReq::parse(">=1.0.0")?;
 //! let v = Version::parse("1.0.0")?;
 //!
 //! assert!(r.to_string() == ">=1.0.0".to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,7 @@ extern crate diesel;
 // We take the common approach of keeping our own module system private, and
 // just re-exporting the interface that we want.
 
+pub use semver_parser::Compat;
 pub use version::Identifier::{AlphaNumeric, Numeric};
 pub use version::{Identifier, SemVerError, Version};
 pub use version_req::{ReqParseError, VersionReq};

--- a/src/version.rs
+++ b/src/version.rs
@@ -394,20 +394,11 @@ mod tests {
             return Err(SemVerError::ParseError(e.to_string()));
         }
 
-        assert_eq!(
-            Version::parse(""),
-            parse_error("expected more input")
-        );
-        assert_eq!(
-            Version::parse("  "),
-            parse_error("expected more input")
-        );
+        assert_eq!(Version::parse(""), parse_error("expected more input"));
+        assert_eq!(Version::parse("  "), parse_error("expected more input"));
         assert_eq!(Version::parse("1"), parse_error("expected more input"));
         assert_eq!(Version::parse("1.2"), parse_error("expected more input"));
-        assert_eq!(
-            Version::parse("1.2.3-"),
-            parse_error("expected more input")
-        );
+        assert_eq!(Version::parse("1.2.3-"), parse_error("expected more input"));
         assert_eq!(
             Version::parse("a.b.c"),
             parse_error("encountered unexpected token: AlphaNumeric(\"a\")")
@@ -538,9 +529,7 @@ mod tests {
                 major: 1,
                 minor: 1,
                 patch: 0,
-                pre: vec![
-                    Identifier::AlphaNumeric(String::from("beta-10")),
-                ],
+                pre: vec![Identifier::AlphaNumeric(String::from("beta-10")),],
                 build: Vec::new(),
             })
         );

--- a/src/version.rs
+++ b/src/version.rs
@@ -237,7 +237,7 @@ impl Version {
 
         match res {
             // Convert plain String error into proper ParseError
-            Err(e) => Err(SemVerError::ParseError(e)),
+            Err(e) => Err(SemVerError::ParseError(e.to_string())),
             Ok(v) => Ok(From::from(v)),
         }
     }
@@ -396,25 +396,25 @@ mod tests {
 
         assert_eq!(
             Version::parse(""),
-            parse_error("Error parsing major identifier")
+            parse_error("expected more input")
         );
         assert_eq!(
             Version::parse("  "),
-            parse_error("Error parsing major identifier")
+            parse_error("expected more input")
         );
-        assert_eq!(Version::parse("1"), parse_error("Expected dot"));
-        assert_eq!(Version::parse("1.2"), parse_error("Expected dot"));
+        assert_eq!(Version::parse("1"), parse_error("expected more input"));
+        assert_eq!(Version::parse("1.2"), parse_error("expected more input"));
         assert_eq!(
             Version::parse("1.2.3-"),
-            parse_error("Error parsing prerelease")
+            parse_error("expected more input")
         );
         assert_eq!(
             Version::parse("a.b.c"),
-            parse_error("Error parsing major identifier")
+            parse_error("encountered unexpected token: AlphaNumeric(\"a\")")
         );
         assert_eq!(
             Version::parse("1.2.3 abc"),
-            parse_error("Extra junk after valid version:  abc")
+            parse_error("expected end of input, but got: [AlphaNumeric(\"abc\")]")
         );
 
         assert_eq!(
@@ -854,18 +854,18 @@ mod tests {
             return Err(SemVerError::ParseError(e.to_string()));
         }
 
-        assert_eq!("".parse(), parse_error("Error parsing major identifier"));
-        assert_eq!("  ".parse(), parse_error("Error parsing major identifier"));
-        assert_eq!("1".parse(), parse_error("Expected dot"));
-        assert_eq!("1.2".parse(), parse_error("Expected dot"));
-        assert_eq!("1.2.3-".parse(), parse_error("Error parsing prerelease"));
+        assert_eq!("".parse(), parse_error("expected more input"));
+        assert_eq!("  ".parse(), parse_error("expected more input"));
+        assert_eq!("1".parse(), parse_error("expected more input"));
+        assert_eq!("1.2".parse(), parse_error("expected more input"));
+        assert_eq!("1.2.3-".parse(), parse_error("expected more input"));
         assert_eq!(
             "a.b.c".parse(),
-            parse_error("Error parsing major identifier")
+            parse_error("encountered unexpected token: AlphaNumeric(\"a\")")
         );
         assert_eq!(
             "1.2.3 abc".parse(),
-            parse_error("Extra junk after valid version:  abc")
+            parse_error("expected end of input, but got: [AlphaNumeric(\"abc\")]")
         );
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -531,6 +531,19 @@ mod tests {
                 build: vec![Identifier::AlphaNumeric(String::from("0851523"))],
             })
         );
+        // for https://nodejs.org/dist/index.json, where some older npm versions are "1.1.0-beta-10"
+        assert_eq!(
+            Version::parse("1.1.0-beta-10"),
+            Ok(Version {
+                major: 1,
+                minor: 1,
+                patch: 0,
+                pre: vec![
+                    Identifier::AlphaNumeric(String::from("beta-10")),
+                ],
+                build: Vec::new(),
+            })
+        );
     }
 
     #[test]

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -642,11 +642,10 @@ mod test {
         assert_not_match(&r, &["0.9.1", "0.1.0", "0.1.1-beta2.a", "0.1.0-beta2"]);
     }
 
-    // TODO: this doesn't work yet, but can be added to semver-parser
     #[test]
-    #[ignore]
     fn test_parse_metadata_see_issue_88_see_issue_88() {
         for op in &[Op::Ex, Op::Gt, Op::GtEq, Op::Lt, Op::LtEq] {
+            println!("{} 1.2.3+meta", op);
             req(&format!("{} 1.2.3+meta", op));
         }
     }

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -659,6 +659,7 @@ mod test {
         assert_match(&r, &["1.0.0", "2.0.0"]);
         assert_not_match(&r, &["0.1.0", "0.0.1", "1.0.0-pre", "2.0.0-pre"]);
 
+        // https://github.com/steveklabnik/semver/issues/53
         let r = req(">= 2.1.0-alpha2");
 
         assert_match(&r, &["2.1.0-alpha2", "2.1.0-alpha3", "2.1.0", "3.0.0"]);
@@ -732,6 +733,21 @@ mod test {
             &["0.5.1-alpha1", "0.5.2-alpha3", "0.5.5-pre", "0.5.0-pre"],
         );
         assert_not_match(&r, &["0.6.0", "0.6.0-pre"]);
+
+        // https://github.com/steveklabnik/semver/issues/56
+        let r = req("1.2.3 - 2.3.4");
+        assert_eq!(r.to_string(), ">=1.2.3, <=2.3.4");
+        assert_match(&r, &["1.2.3", "1.2.10", "2.0.0", "2.3.4"]);
+        assert_not_match(&r, &["1.0.0", "1.2.2", "1.2.3-alpha1", "2.3.5"]);
+    }
+
+    // https://github.com/steveklabnik/semver/issues/55
+    #[test]
+    pub fn test_whitespace_delimited_comparator_sets() {
+        let r = req("> 0.0.9 <= 2.5.3");
+        assert_eq!(r.to_string(), ">0.0.9, <=2.5.3".to_string());
+        assert_match(&r, &["0.0.10", "1.0.0", "2.5.3"]);
+        assert_not_match(&r, &["0.0.8", "2.5.4"]);
     }
 
     #[test]
@@ -902,6 +918,7 @@ mod test {
         assert_not_match(&r, &["1.9.0", "1.0.9", "2.0.1", "0.1.3"]);
     }
 
+    // https://github.com/steveklabnik/semver/issues/57
     #[test]
     pub fn test_parsing_logical_or() {
         let r = req("=1.2.3 || =2.3.4");

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -13,8 +13,7 @@ use std::fmt;
 use std::str;
 
 use semver_parser;
-pub use semver_parser::Compat; // re-export this
-use semver_parser::RangeSet;
+use semver_parser::{Compat, RangeSet};
 use version::Identifier;
 use Version;
 

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use std::str;
 
 use semver_parser;
+use semver_parser::RangeSet;
 use version::Identifier;
 use Version;
 
@@ -21,24 +22,23 @@ use serde::de::{self, Deserialize, Deserializer, Visitor};
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, Serializer};
 
-use self::Op::{Compatible, Ex, Gt, GtEq, Lt, LtEq, Tilde, Wildcard};
+use self::Op::{Ex, Gt, GtEq, Lt, LtEq};
 use self::ReqParseError::*;
-use self::WildcardVersion::{Major, Minor, Patch};
 
-/// A `VersionReq` is a struct containing a list of predicates that can apply to ranges of version
+/// A `VersionReq` is a struct containing a list of ranges that can apply to ranges of version
 /// numbers. Matching operations can then be done with the `VersionReq` against a particular
 /// version to see if it satisfies some or all of the constraints.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
 #[cfg_attr(feature = "diesel", sql_type = "diesel::sql_types::Text")]
 pub struct VersionReq {
-    predicates: Vec<Predicate>,
+    ranges: Vec<Range>,
 }
 
-impl From<semver_parser::range::VersionReq> for VersionReq {
-    fn from(other: semver_parser::range::VersionReq) -> VersionReq {
+impl From<semver_parser::RangeSet> for VersionReq {
+    fn from(range_set: semver_parser::RangeSet) -> VersionReq {
         VersionReq {
-            predicates: other.predicates.into_iter().map(From::from).collect(),
+            ranges: range_set.ranges.into_iter().map(From::from).collect(),
         }
     }
 }
@@ -83,40 +83,35 @@ impl<'de> Deserialize<'de> for VersionReq {
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-enum WildcardVersion {
-    Major,
-    Minor,
-    Patch,
+enum Op {
+    Ex,   // Exact
+    Gt,   // Greater than
+    GtEq, // Greater than or equal to
+    Lt,   // Less than
+    LtEq, // Less than or equal to
+}
+
+impl From<semver_parser::Op> for Op {
+    fn from(op: semver_parser::Op) -> Op {
+        match op {
+            semver_parser::Op::Eq => Op::Ex,
+            semver_parser::Op::Gt => Op::Gt,
+            semver_parser::Op::Gte => Op::GtEq,
+            semver_parser::Op::Lt => Op::Lt,
+            semver_parser::Op::Lte => Op::LtEq,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-enum Op {
-    Ex,                        // Exact
-    Gt,                        // Greater than
-    GtEq,                      // Greater than or equal to
-    Lt,                        // Less than
-    LtEq,                      // Less than or equal to
-    Tilde,                     // e.g. ~1.0.0
-    Compatible,                // compatible by definition of semver, indicated by ^
-    Wildcard(WildcardVersion), // x.y.*, x.*, *
+struct Range {
+    predicates: Vec<Predicate>,
 }
 
-impl From<semver_parser::range::Op> for Op {
-    fn from(other: semver_parser::range::Op) -> Op {
-        use semver_parser::range;
-        match other {
-            range::Op::Ex => Op::Ex,
-            range::Op::Gt => Op::Gt,
-            range::Op::GtEq => Op::GtEq,
-            range::Op::Lt => Op::Lt,
-            range::Op::LtEq => Op::LtEq,
-            range::Op::Tilde => Op::Tilde,
-            range::Op::Compatible => Op::Compatible,
-            range::Op::Wildcard(version) => match version {
-                range::WildcardVersion::Major => Op::Wildcard(WildcardVersion::Major),
-                range::WildcardVersion::Minor => Op::Wildcard(WildcardVersion::Minor),
-                range::WildcardVersion::Patch => Op::Wildcard(WildcardVersion::Patch),
-            },
+impl From<semver_parser::Range> for Range {
+    fn from(range: semver_parser::Range) -> Range {
+        Range {
+            predicates: range.comparator_set.into_iter().map(From::from).collect(),
         }
     }
 }
@@ -130,14 +125,24 @@ struct Predicate {
     pre: Vec<Identifier>,
 }
 
-impl From<semver_parser::range::Predicate> for Predicate {
-    fn from(other: semver_parser::range::Predicate) -> Predicate {
+impl From<semver_parser::Comparator> for Predicate {
+    fn from(comparator: semver_parser::Comparator) -> Predicate {
         Predicate {
-            op: From::from(other.op),
-            major: other.major,
-            minor: other.minor,
-            patch: other.patch,
-            pre: other.pre.into_iter().map(From::from).collect(),
+            op: From::from(comparator.op),
+            major: comparator.major,
+            // TODO: don't need the Option for these...
+            minor: Some(comparator.minor),
+            patch: Some(comparator.patch),
+            pre: comparator.pre.into_iter().map(From::from).collect(),
+        }
+    }
+}
+
+impl From<semver_parser::Identifier> for Identifier {
+    fn from(identifier: semver_parser::Identifier) -> Identifier {
+        match identifier {
+            semver_parser::Identifier::Numeric(n) => Identifier::Numeric(n),
+            semver_parser::Identifier::AlphaNumeric(s) => Identifier::AlphaNumeric(s),
         }
     }
 }
@@ -209,7 +214,7 @@ impl VersionReq {
     /// let anything = VersionReq::any();
     /// ```
     pub fn any() -> VersionReq {
-        VersionReq { predicates: vec![] }
+        VersionReq { ranges: vec![] }
     }
 
     /// `parse()` is the main constructor of a `VersionReq`. It takes a string like `"^1.2.3"`
@@ -262,15 +267,15 @@ impl VersionReq {
     /// You may also encounter an `UnimplementedVersionRequirement` error, which indicates that a
     /// given requirement syntax is not yet implemented in this crate.
     pub fn parse(input: &str) -> Result<VersionReq, ReqParseError> {
-        let res = semver_parser::range::parse(input);
+        let range_set = input.parse::<RangeSet>();
 
-        if let Ok(v) = res {
+        if let Ok(v) = range_set {
             return Ok(From::from(v));
         }
 
         match VersionReq::parse_deprecated(input) {
             Some(v) => Err(ReqParseError::DeprecatedVersionRequirement(v)),
-            None => Err(From::from(res.err().unwrap())),
+            None => Err(From::from(range_set.err().unwrap())),
         }
     }
 
@@ -298,7 +303,9 @@ impl VersionReq {
     /// ```
     pub fn exact(version: &Version) -> VersionReq {
         VersionReq {
-            predicates: vec![Predicate::exact(version)],
+            ranges: vec![Range {
+                predicates: vec![Predicate::exact(version)],
+            }],
         }
     }
 
@@ -317,16 +324,14 @@ impl VersionReq {
     /// assert!(exact.matches(&version));
     /// ```
     pub fn matches(&self, version: &Version) -> bool {
-        // no predicates means anything matches
-        if self.predicates.is_empty() {
+        // no ranges means anything matches
+        if self.ranges.is_empty() {
             return true;
         }
 
-        self.predicates.iter().all(|p| p.matches(version))
-            && self
-                .predicates
-                .iter()
-                .any(|p| p.pre_tag_is_compatible(version))
+        self.ranges
+            .iter()
+            .any(|r| r.matches(version) && r.pre_tag_is_compatible(version))
     }
 
     /// `is_exact()` returns `true` if there is exactly one version which could match this
@@ -351,11 +356,13 @@ impl VersionReq {
     /// use_is_exact().unwrap();
     /// ```
     pub fn is_exact(&self) -> bool {
-        if let [predicate] = self.predicates.as_slice() {
-            predicate.has_exactly_one_match()
-        } else {
-            false
+        if let [range] = self.ranges.as_slice() {
+            if let [predicate] = range.predicates.as_slice() {
+                return predicate.has_exactly_one_match();
+            }
         }
+
+        false
     }
 }
 
@@ -364,6 +371,16 @@ impl str::FromStr for VersionReq {
 
     fn from_str(s: &str) -> Result<VersionReq, ReqParseError> {
         VersionReq::parse(s)
+    }
+}
+
+impl Range {
+    fn matches(&self, ver: &Version) -> bool {
+        self.predicates.iter().all(|p| p.matches(ver))
+    }
+
+    fn pre_tag_is_compatible(&self, ver: &Version) -> bool {
+        self.predicates.iter().any(|p| p.pre_tag_is_compatible(ver))
     }
 }
 
@@ -386,9 +403,6 @@ impl Predicate {
             GtEq => self.matches_exact(ver) || self.matches_greater(ver),
             Lt => !self.matches_exact(ver) && !self.matches_greater(ver),
             LtEq => !self.matches_greater(ver),
-            Tilde => self.matches_tilde(ver),
-            Compatible => self.is_compatible(ver),
-            Wildcard(_) => self.matches_wildcard(ver),
         }
     }
 
@@ -466,83 +480,6 @@ impl Predicate {
         false
     }
 
-    // see https://www.npmjs.com/package/semver for behavior
-    fn matches_tilde(&self, ver: &Version) -> bool {
-        let minor = match self.minor {
-            Some(n) => n,
-            None => return self.major == ver.major,
-        };
-
-        match self.patch {
-            Some(patch) => {
-                self.major == ver.major
-                    && minor == ver.minor
-                    && (ver.patch > patch || (ver.patch == patch && self.pre_is_compatible(ver)))
-            }
-            None => self.major == ver.major && minor == ver.minor,
-        }
-    }
-
-    // see https://www.npmjs.com/package/semver for behavior
-    fn is_compatible(&self, ver: &Version) -> bool {
-        if self.major != ver.major {
-            return false;
-        }
-
-        let minor = match self.minor {
-            Some(n) => n,
-            None => return self.major == ver.major,
-        };
-
-        match self.patch {
-            Some(patch) => {
-                if self.major == 0 {
-                    if minor == 0 {
-                        ver.minor == minor && ver.patch == patch && self.pre_is_compatible(ver)
-                    } else {
-                        ver.minor == minor
-                            && (ver.patch > patch
-                                || (ver.patch == patch && self.pre_is_compatible(ver)))
-                    }
-                } else {
-                    ver.minor > minor
-                        || (ver.minor == minor
-                            && (ver.patch > patch
-                                || (ver.patch == patch && self.pre_is_compatible(ver))))
-                }
-            }
-            None => {
-                if self.major == 0 {
-                    ver.minor == minor
-                } else {
-                    ver.minor >= minor
-                }
-            }
-        }
-    }
-
-    fn pre_is_compatible(&self, ver: &Version) -> bool {
-        ver.pre.is_empty() || ver.pre >= self.pre
-    }
-
-    // see https://www.npmjs.com/package/semver for behavior
-    fn matches_wildcard(&self, ver: &Version) -> bool {
-        match self.op {
-            Wildcard(Major) => true,
-            Wildcard(Minor) => self.major == ver.major,
-            Wildcard(Patch) => {
-                match self.minor {
-                    Some(minor) => self.major == ver.major && minor == ver.minor,
-                    None => {
-                        // minor and patch version astericks mean match on major
-                        self.major == ver.major
-                    }
-                }
-            }
-            _ => false, // unreachable
-        }
-    }
-
     fn has_exactly_one_match(&self) -> bool {
         self.op == Ex && self.minor.is_some() && self.patch.is_some()
     }
@@ -550,10 +487,12 @@ impl Predicate {
 
 impl fmt::Display for VersionReq {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        if self.predicates.is_empty() {
+        // TODO: is this right?
+        if self.ranges.is_empty() {
             write!(fmt, "*")?;
         } else {
-            for (i, ref pred) in self.predicates.iter().enumerate() {
+            // TODO: is this right?
+            for (i, ref pred) in self.ranges.iter().enumerate() {
                 if i == 0 {
                     write!(fmt, "{}", pred)?;
                 } else {
@@ -566,18 +505,24 @@ impl fmt::Display for VersionReq {
     }
 }
 
+impl fmt::Display for Range {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        // TODO: is this right?
+        for (i, ref pred) in self.predicates.iter().enumerate() {
+            if i == 0 {
+                write!(fmt, "{}", pred)?;
+            } else {
+                write!(fmt, ", {}", pred)?;
+            }
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Display for Predicate {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        // TODO: don't need the match here
         match self.op {
-            Wildcard(Major) => write!(fmt, "*")?,
-            Wildcard(Minor) => write!(fmt, "{}.*", self.major)?,
-            Wildcard(Patch) => {
-                if let Some(minor) = self.minor {
-                    write!(fmt, "{}.{}.*", self.major, minor)?
-                } else {
-                    write!(fmt, "{}.*.*", self.major)?
-                }
-            }
             _ => {
                 write!(fmt, "{}{}", self.op, self.major)?;
 
@@ -613,10 +558,6 @@ impl fmt::Display for Op {
             GtEq => write!(fmt, ">=")?,
             Lt => write!(fmt, "<")?,
             LtEq => write!(fmt, "<=")?,
-            Tilde => write!(fmt, "~")?,
-            Compatible => write!(fmt, "^")?,
-            // gets handled specially in Predicate::fmt
-            Wildcard(_) => write!(fmt, "")?,
         }
         Ok(())
     }
@@ -663,7 +604,7 @@ mod test {
     fn test_parsing_default() {
         let r = req("1.0.0");
 
-        assert_eq!(r.to_string(), "^1.0.0".to_string());
+        assert_eq!(r.to_string(), ">=1.0.0, <2.0.0".to_string());
 
         assert_match(&r, &["1.0.0", "1.0.1"]);
         assert_not_match(&r, &["0.9.9", "0.10.0", "0.1.0"]);
@@ -694,17 +635,11 @@ mod test {
         assert_not_match(&r, &["0.9.1", "0.1.0", "0.1.1-beta2.a", "0.1.0-beta2"]);
     }
 
+    // TODO: this doesn't work yet, but can be added to semver-parser
     #[test]
+    #[ignore]
     fn test_parse_metadata_see_issue_88_see_issue_88() {
-        for op in &[
-            Op::Compatible,
-            Op::Ex,
-            Op::Gt,
-            Op::GtEq,
-            Op::Lt,
-            Op::LtEq,
-            Op::Tilde,
-        ] {
+        for op in &[Op::Ex, Op::Gt, Op::GtEq, Op::Lt, Op::LtEq] {
             req(&format!("{} 1.2.3+meta", op));
         }
     }
@@ -753,7 +688,10 @@ mod test {
         assert_not_match(&r, &["0.0.8", "2.5.4"]);
 
         let r = req("0.3.0, 0.4.0");
-        assert_eq!(r.to_string(), "^0.3.0, ^0.4.0".to_string());
+        assert_eq!(
+            r.to_string(),
+            ">=0.3.0, <0.4.0, >=0.4.0, <0.5.0".to_string()
+        );
         assert_not_match(&r, &["0.0.8", "0.3.0", "0.4.0"]);
 
         let r = req("<= 0.2.0, >= 0.5.0");
@@ -761,7 +699,10 @@ mod test {
         assert_not_match(&r, &["0.0.8", "0.3.0", "0.5.1"]);
 
         let r = req("0.1.0, 0.1.4, 0.1.6");
-        assert_eq!(r.to_string(), "^0.1.0, ^0.1.4, ^0.1.6".to_string());
+        assert_eq!(
+            r.to_string(),
+            ">=0.1.0, <0.2.0, >=0.1.4, <0.2.0, >=0.1.6, <0.2.0".to_string()
+        );
         assert_match(&r, &["0.1.6", "0.1.9"]);
         assert_not_match(&r, &["0.1.0", "0.1.4", "0.2.0"]);
 
@@ -769,7 +710,7 @@ mod test {
         assert!(VersionReq::parse("> 0.3.0, ,").is_err());
 
         let r = req(">=0.5.1-alpha3, <0.6");
-        assert_eq!(r.to_string(), ">=0.5.1-alpha3, <0.6".to_string());
+        assert_eq!(r.to_string(), ">=0.5.1-alpha3, <0.6.0".to_string());
         assert_match(
             &r,
             &[
@@ -941,7 +882,7 @@ mod test {
     pub fn test_from_str() {
         assert_eq!(
             "1.0.0".parse::<VersionReq>().unwrap().to_string(),
-            "^1.0.0".to_string()
+            ">=1.0.0, <2.0.0".to_string()
         );
         assert_eq!(
             "=1.0.0".parse::<VersionReq>().unwrap().to_string(),
@@ -949,27 +890,27 @@ mod test {
         );
         assert_eq!(
             "~1".parse::<VersionReq>().unwrap().to_string(),
-            "~1".to_string()
+            ">=1.0.0, <2.0.0".to_string()
         );
         assert_eq!(
             "~1.2".parse::<VersionReq>().unwrap().to_string(),
-            "~1.2".to_string()
+            ">=1.2.0, <1.3.0".to_string()
         );
         assert_eq!(
             "^1".parse::<VersionReq>().unwrap().to_string(),
-            "^1".to_string()
+            ">=1.0.0, <2.0.0".to_string()
         );
         assert_eq!(
             "^1.1".parse::<VersionReq>().unwrap().to_string(),
-            "^1.1".to_string()
+            ">=1.1.0, <2.0.0".to_string()
         );
         assert_eq!(
             "*".parse::<VersionReq>().unwrap().to_string(),
-            "*".to_string()
+            ">=0.0.0".to_string()
         );
         assert_eq!(
             "1.*".parse::<VersionReq>().unwrap().to_string(),
-            "1.*".to_string()
+            ">=1.0.0, <2.0.0".to_string()
         );
         assert_eq!(
             "< 1.0.0".parse::<VersionReq>().unwrap().to_string(),
@@ -991,10 +932,10 @@ mod test {
     #[test]
     fn test_cargo3202() {
         let v = "0.*.*".parse::<VersionReq>().unwrap();
-        assert_eq!("0.*.*", format!("{}", v.predicates[0]));
+        assert_eq!(">=0.0.0, <1.0.0", format!("{}", v.ranges[0]));
 
         let v = "0.0.*".parse::<VersionReq>().unwrap();
-        assert_eq!("0.0.*", format!("{}", v.predicates[0]));
+        assert_eq!(">=0.0.0, <0.1.0", format!("{}", v.ranges[0]));
 
         let r = req("0.*.*");
         assert_match(&r, &["0.5.0"]);
@@ -1009,13 +950,13 @@ mod test {
 
     #[test]
     fn test_ordering() {
-        assert!(req("=1") < req("*"));
+        assert!(req("=1") > req("*"));
         assert!(req(">1") < req("*"));
-        assert!(req(">=1") < req("*"));
-        assert!(req("<1") < req("*"));
-        assert!(req("<=1") < req("*"));
-        assert!(req("~1") < req("*"));
-        assert!(req("^1") < req("*"));
+        assert!(req(">=1") > req("*"));
+        assert!(req("<1") > req("*"));
+        assert!(req("<=1") > req("*"));
+        assert!(req("~1") > req("*"));
+        assert!(req("^1") > req("*"));
         assert!(req("*") == req("*"));
     }
 

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -304,7 +304,7 @@ impl VersionReq {
     ///
     /// # fn main() {
     ///     let cargo_version = VersionReq::parse_compat("1.2.3", Compat::Cargo);
-    ///     let node_version = VersionReq::parse_compat("1.2.3", Compat::Node);
+    ///     let npm_version = VersionReq::parse_compat("1.2.3", Compat::Npm);
     /// # }
     /// ```
     pub fn parse_compat(input: &str, compat: Compat) -> Result<VersionReq, ReqParseError> {
@@ -518,7 +518,7 @@ impl fmt::Display for Range {
         for (i, ref pred) in self.predicates.iter().enumerate() {
             if i == 0 {
                 write!(fmt, "{}", pred)?;
-            } else if self.compat == Compat::Node {
+            } else if self.compat == Compat::Npm {
                 // Node does not expect commas between predicates
                 write!(fmt, " {}", pred)?;
             } else {
@@ -574,8 +574,8 @@ mod test {
         VersionReq::parse(s).unwrap()
     }
 
-    fn req_node(s: &str) -> VersionReq {
-        VersionReq::parse_compat(s, Compat::Node).unwrap()
+    fn req_npm(s: &str) -> VersionReq {
+        VersionReq::parse_compat(s, Compat::Npm).unwrap()
     }
 
     fn version(s: &str) -> Version {
@@ -616,8 +616,8 @@ mod test {
     }
 
     #[test]
-    fn test_parsing_default_node() {
-        let r = req_node("1.0.0");
+    fn test_parsing_default_npm() {
+        let r = req_npm("1.0.0");
 
         assert_eq!(r.to_string(), "=1.0.0".to_string());
 
@@ -759,28 +759,28 @@ mod test {
     }
 
     #[test]
-    pub fn test_multiple_node() {
-        let r = req_node("> 0.0.9, <= 2.5.3");
+    pub fn test_multiple_npm() {
+        let r = req_npm("> 0.0.9, <= 2.5.3");
         assert_eq!(r.to_string(), ">0.0.9 <=2.5.3".to_string());
         assert_match(&r, &["0.0.10", "1.0.0", "2.5.3"]);
         assert_not_match(&r, &["0.0.8", "2.5.4"]);
 
-        let r = req_node("0.3.0, 0.4.0");
+        let r = req_npm("0.3.0, 0.4.0");
         assert_eq!(r.to_string(), "=0.3.0 =0.4.0".to_string());
         assert_not_match(&r, &["0.0.8", "0.3.0", "0.4.0"]);
 
-        let r = req_node("<= 0.2.0, >= 0.5.0");
+        let r = req_npm("<= 0.2.0, >= 0.5.0");
         assert_eq!(r.to_string(), "<=0.2.0 >=0.5.0".to_string());
         assert_not_match(&r, &["0.0.8", "0.3.0", "0.5.1"]);
 
-        let r = req_node("0.1.0, 0.1.4, 0.1.6");
+        let r = req_npm("0.1.0, 0.1.4, 0.1.6");
         assert_eq!(r.to_string(), "=0.1.0 =0.1.4 =0.1.6".to_string());
         assert_not_match(&r, &["0.1.0", "0.1.4", "0.1.6", "0.2.0"]);
 
         assert!(VersionReq::parse("> 0.1.0,").is_err());
         assert!(VersionReq::parse("> 0.3.0, ,").is_err());
 
-        let r = req_node(">=0.5.1-alpha3, <0.6");
+        let r = req_npm(">=0.5.1-alpha3, <0.6");
         assert_eq!(r.to_string(), ">=0.5.1-alpha3 <0.6.0".to_string());
         assert_match(
             &r,
@@ -952,19 +952,19 @@ mod test {
     }
 
     #[test]
-    pub fn test_parsing_logical_or_node() {
-        let r = req_node("=1.2.3 || =2.3.4");
+    pub fn test_parsing_logical_or_npm() {
+        let r = req_npm("=1.2.3 || =2.3.4");
         assert_eq!(r.to_string(), "=1.2.3 || =2.3.4".to_string());
         assert_match(&r, &["1.2.3", "2.3.4"]);
         assert_not_match(&r, &["1.0.0", "2.9.0", "0.1.4"]);
         assert_not_match(&r, &["1.2.3-beta1", "2.3.4-alpha", "1.2.3-pre"]);
 
-        let r = req_node("1.1 || =1.2.3");
+        let r = req_npm("1.1 || =1.2.3");
         assert_eq!(r.to_string(), ">=1.1.0 <1.2.0 || =1.2.3".to_string());
         assert_match(&r, &["1.1.0", "1.1.12", "1.2.3"]);
         assert_not_match(&r, &["1.0.0", "1.2.2", "1.3.0"]);
 
-        let r = req_node("6.* || 8.* || >= 10.*");
+        let r = req_npm("6.* || 8.* || >= 10.*");
         assert_eq!(
             r.to_string(),
             ">=6.0.0 <7.0.0 || >=8.0.0 <9.0.0 || >=10.0.0".to_string()

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -296,8 +296,16 @@ impl VersionReq {
     /// [`ReqParseError`]: enum.ReqParseError.html
     ///
     /// # Examples
+    ///
     /// ```
-    /// // TODO
+    /// extern crate semver_parser;
+    /// use semver::VersionReq;
+    /// use semver_parser::Compat;
+    ///
+    /// # fn main() {
+    ///     let cargo_version = VersionReq::parse_compat("1.2.3", Compat::Cargo);
+    ///     let node_version = VersionReq::parse_compat("1.2.3", Compat::Node);
+    /// # }
     /// ```
     pub fn parse_compat(input: &str, compat: Compat) -> Result<VersionReq, ReqParseError> {
         let range_set = RangeSet::parse(input, compat);

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -527,7 +527,7 @@ impl fmt::Display for Predicate {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(
             fmt,
-            "{} {}.{}.{}",
+            "{}{}.{}.{}",
             self.op, self.major, self.minor, self.patch
         )?;
 
@@ -613,7 +613,7 @@ mod test {
     fn test_parsing_default_node() {
         let r = req_node("1.0.0");
 
-        assert_eq!(r.to_string(), "= 1.0.0".to_string());
+        assert_eq!(r.to_string(), "=1.0.0".to_string());
 
         assert_match(&r, &["1.0.0"]);
         assert_not_match(&r, &["0.9.9", "0.10.0", "0.1.0", "1.0.1"]);
@@ -740,27 +740,27 @@ mod test {
     #[test]
     pub fn test_multiple_node() {
         let r = req_node("> 0.0.9, <= 2.5.3");
-        assert_eq!(r.to_string(), "> 0.0.9 <= 2.5.3".to_string());
+        assert_eq!(r.to_string(), ">0.0.9 <=2.5.3".to_string());
         assert_match(&r, &["0.0.10", "1.0.0", "2.5.3"]);
         assert_not_match(&r, &["0.0.8", "2.5.4"]);
 
         let r = req_node("0.3.0, 0.4.0");
-        assert_eq!(r.to_string(), "= 0.3.0 = 0.4.0".to_string());
+        assert_eq!(r.to_string(), "=0.3.0 =0.4.0".to_string());
         assert_not_match(&r, &["0.0.8", "0.3.0", "0.4.0"]);
 
         let r = req_node("<= 0.2.0, >= 0.5.0");
-        assert_eq!(r.to_string(), "<= 0.2.0 >= 0.5.0".to_string());
+        assert_eq!(r.to_string(), "<=0.2.0 >=0.5.0".to_string());
         assert_not_match(&r, &["0.0.8", "0.3.0", "0.5.1"]);
 
         let r = req_node("0.1.0, 0.1.4, 0.1.6");
-        assert_eq!(r.to_string(), "= 0.1.0 = 0.1.4 = 0.1.6".to_string());
+        assert_eq!(r.to_string(), "=0.1.0 =0.1.4 =0.1.6".to_string());
         assert_not_match(&r, &["0.1.0", "0.1.4", "0.1.6", "0.2.0"]);
 
         assert!(VersionReq::parse("> 0.1.0,").is_err());
         assert!(VersionReq::parse("> 0.3.0, ,").is_err());
 
         let r = req_node(">=0.5.1-alpha3, <0.6");
-        assert_eq!(r.to_string(), ">= 0.5.1-alpha3 < 0.6.0".to_string());
+        assert_eq!(r.to_string(), ">=0.5.1-alpha3 <0.6.0".to_string());
         assert_match(
             &r,
             &[
@@ -908,20 +908,20 @@ mod test {
     #[test]
     pub fn test_parsing_logical_or() {
         let r = req("=1.2.3 || =2.3.4");
-        assert_eq!(r.to_string(), "= 1.2.3 || = 2.3.4".to_string());
+        assert_eq!(r.to_string(), "=1.2.3 || =2.3.4".to_string());
         assert_match(&r, &["1.2.3", "2.3.4"]);
         assert_not_match(&r, &["1.0.0", "2.9.0", "0.1.4"]);
         assert_not_match(&r, &["1.2.3-beta1", "2.3.4-alpha", "1.2.3-pre"]);
 
         let r = req("1.1 || =1.2.3");
-        assert_eq!(r.to_string(), ">= 1.1.0, < 1.2.0 || = 1.2.3".to_string());
+        assert_eq!(r.to_string(), ">=1.1.0, <1.2.0 || =1.2.3".to_string());
         assert_match(&r, &["1.1.0", "1.1.12", "1.2.3"]);
         assert_not_match(&r, &["1.0.0", "1.2.2", "1.3.0"]);
 
         let r = req("6.* || 8.* || >= 10.*");
         assert_eq!(
             r.to_string(),
-            ">= 6.0.0, < 7.0.0 || >= 8.0.0, < 9.0.0 || >= 10.0.0".to_string()
+            ">=6.0.0, <7.0.0 || >=8.0.0, <9.0.0 || >=10.0.0".to_string()
         );
         assert_match(&r, &["6.0.0", "6.1.2"]);
         assert_match(&r, &["8.0.0", "8.2.4"]);
@@ -932,20 +932,20 @@ mod test {
     #[test]
     pub fn test_parsing_logical_or_node() {
         let r = req_node("=1.2.3 || =2.3.4");
-        assert_eq!(r.to_string(), "= 1.2.3 || = 2.3.4".to_string());
+        assert_eq!(r.to_string(), "=1.2.3 || =2.3.4".to_string());
         assert_match(&r, &["1.2.3", "2.3.4"]);
         assert_not_match(&r, &["1.0.0", "2.9.0", "0.1.4"]);
         assert_not_match(&r, &["1.2.3-beta1", "2.3.4-alpha", "1.2.3-pre"]);
 
         let r = req_node("1.1 || =1.2.3");
-        assert_eq!(r.to_string(), ">= 1.1.0 < 1.2.0 || = 1.2.3".to_string());
+        assert_eq!(r.to_string(), ">=1.1.0 <1.2.0 || =1.2.3".to_string());
         assert_match(&r, &["1.1.0", "1.1.12", "1.2.3"]);
         assert_not_match(&r, &["1.0.0", "1.2.2", "1.3.0"]);
 
         let r = req_node("6.* || 8.* || >= 10.*");
         assert_eq!(
             r.to_string(),
-            ">= 6.0.0 < 7.0.0 || >= 8.0.0 < 9.0.0 || >= 10.0.0".to_string()
+            ">=6.0.0 <7.0.0 || >=8.0.0 <9.0.0 || >=10.0.0".to_string()
         );
         assert_match(&r, &["6.0.0", "6.1.2"]);
         assert_match(&r, &["8.0.0", "8.2.4"]);

--- a/src/version_req.rs
+++ b/src/version_req.rs
@@ -306,10 +306,10 @@ impl VersionReq {
             return Ok(From::from(v));
         }
 
-        return match VersionReq::parse_deprecated(input) {
+        match VersionReq::parse_deprecated(input) {
             Some(v) => Err(ReqParseError::DeprecatedVersionRequirement(v)),
             None => Err(From::from(range_set.err().unwrap())),
-        };
+        }
     }
 
     fn parse_deprecated(version: &str) -> Option<VersionReq> {
@@ -510,13 +510,11 @@ impl fmt::Display for Range {
         for (i, ref pred) in self.predicates.iter().enumerate() {
             if i == 0 {
                 write!(fmt, "{}", pred)?;
+            } else if self.compat == Compat::Node {
+                // Node does not expect commas between predicates
+                write!(fmt, " {}", pred)?;
             } else {
-                if self.compat == Compat::Node {
-                    // Node does not expect commas between predicates
-                    write!(fmt, " {}", pred)?;
-                } else {
-                    write!(fmt, ", {}", pred)?;
-                }
+                write!(fmt, ", {}", pred)?;
             }
         }
         Ok(())

--- a/tests/deprecation.rs
+++ b/tests/deprecation.rs
@@ -10,8 +10,6 @@ fn test_regressions() {
         ("0.1.0.", VersionReq::parse("0.1.0").unwrap()),
         ("0.3.1.3", VersionReq::parse("0.3.13").unwrap()),
         ("0.2*", VersionReq::parse("0.2.*").unwrap()),
-        // TODO: this actually parses as '*' now, not sure if that's OK
-        // ("*.0", VersionReq::any()),
     ];
 
     for (version, requirement) in versions.into_iter() {

--- a/tests/deprecation.rs
+++ b/tests/deprecation.rs
@@ -10,7 +10,8 @@ fn test_regressions() {
         ("0.1.0.", VersionReq::parse("0.1.0").unwrap()),
         ("0.3.1.3", VersionReq::parse("0.3.13").unwrap()),
         ("0.2*", VersionReq::parse("0.2.*").unwrap()),
-        ("*.0", VersionReq::any()),
+        // TODO: this actually parses as '*' now, not sure if that's OK
+        // ("*.0", VersionReq::any()),
     ];
 
     for (version, requirement) in versions.into_iter() {


### PR DESCRIPTION
This combines the changes from [mikrostew/semver@new-parser](https://github.com/mikrostew/semver/tree/new-parser) and the current master branch which makes it compatible with `semver-parser` `0.10.0` that hasn't quite been released. In order for the tests pass, it patches the `semver-parser` dependency to use GitHub.

Tracking Items Left:
- [x] #58 
- [x] fix test for #88 
- [x] Merge steveklabnik/semver-parser#47
- [x] Remove deprecation for `VersionReq::any()` as `'*'`
- [x] `VersionReq::parse_compat` doc example
- [x] Rename `Compat::Node` to `Compat::Npm`
- [x] Release `0.10.0` of `semver-parser` crate
- [ ] Unpatch `semver-parser` in `Cargo.toml`